### PR TITLE
Add error response for STATIC type images

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -202,16 +202,17 @@ FFW.UI = FFW.RPCObserver.create(
                 'secondaryGraphic' in request.params ||
                 'softButtons' in request.params ||
                 'customPresets' in request.params) {
+
+                if (this.errorResponsePull[request.id].type === 'STATIC') {
+                  this.sendError(SDL.SDLModel.data.resultCode['UNSUPPORTED_RESOURCE'], 
+                                request.id, 
+                                request.method, 
+                                'Image of STATIC type is not supported on HMI. Request was not displayed');
+                  return;
+                }
+
                 this.errorResponsePull[request.id].code =
                   SDL.SDLModel.data.resultCode['WARNINGS'];
-                //} else {
-                //    //If no available data sent error response and stop
-                // process current request
-                // this.sendError(this.errorResponsePull[request.id].code,
-                // request.id, request.method, "Unsupported " +
-                // this.errorResponsePull[request.id].type + " type. Request
-                // was not processed."); this.errorResponsePull[request.id] =
-                // null;  return;
               }
             }
             SDL.TurnByTurnView.deactivate();

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -207,7 +207,7 @@ FFW.UI = FFW.RPCObserver.create(
                   this.sendError(SDL.SDLModel.data.resultCode['UNSUPPORTED_RESOURCE'], 
                                 request.id, 
                                 request.method, 
-                                'Image of STATIC type is not supported on HMI. Request was not displayed');
+                                'Image of STATIC type is not supported on HMI. Request was not processed');
                   return;
                 }
 


### PR DESCRIPTION
Implements/Fixes [#320](https://github.com/smartdevicelink/sdl_hmi/issues/320)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added error response with UNSUPPORTED_RESOURCE in case STATIC image comes in request 
for Show RPC.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
