### PR TITLE
[SDL-0273] Template WEB_VIEW should be available only for WebEngine apps with app hmi type WEB_VIEW

### DIFF
--- a/app/AppViews.js
+++ b/app/AppViews.js
@@ -45,6 +45,7 @@ SDL.AppViews = Em.ContainerView.extend(
       SDL.HomeView,
       SDL.MediaView,
       SDL.NavigationAppView,
+      SDL.WebEngineView,
       SDL.InfoView,
       SDL.PhoneView,
       SDL.ClimateView,

--- a/app/StateManager.js
+++ b/app/StateManager.js
@@ -475,6 +475,27 @@ var StateManager = Em.StateManager.extend(
         }
       }
     ),
+    webViewApp: Em.State.create(
+      {
+        modelBinding: 'SDL.RCModulesController',
+        enter: function() {
+          if (SDL.SDLModel.data.mediaPlayerActive) {
+            SDL.SDLController.onEventChanged('player', false);
+            this.model.currentAudioModel.deactivateCD();
+            this.model.currentAudioModel.deactivateUSB();
+            this.model.currentAudioModel.deactivateRadio();
+          }
+          this.model.currentAudioModel.set('activeState', SDL.States.nextState);
+          this._super();
+        },
+        exit: function() {
+          this._super();
+          SDL.SDLModel.data.stateLimited = SDL.SDLController.model.appID;
+          SDL.SDLModel.data.set('limitedExist', false);
+          SDL.SDLController.deactivateApp();
+        }
+      }
+    ),
     /** Navigation state */
     navigation: Em.State.create(
       {

--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -558,21 +558,6 @@ SDL.InfoController = Em.Object.create(
       if (SDL.SDLController.model) {
         SDL.SDLController.model.set('active', true);
       }
-      /**
-       * Go to SDL state
-       */
-      if (SDL.SDLController.model.appType) {
-        for (var i = 0; i < SDL.SDLController.model.appType.length; i++) {
-          if (SDL.SDLController.model.appType[i] == 'NAVIGATION' ||
-              SDL.SDLController.model.appType[i] == 'PROJECTION') {
-            SDL.BaseNavigationView.update();
-            SDL.States.goToStates('navigationApp.baseNavigation');
-            return;
-          }
-        }
-      }
-      SDL.States.goToStates('info.nonMedia');
-      //SDL.States.goToStates('media.sdlmedia');
     }
   }
 );

--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -325,15 +325,22 @@ SDL.InfoController = Em.Object.create(
 
       if (policyAppID in SDL.SDLModel.webApplicationFramesMap) {
         let frame = SDL.SDLModel.webApplicationFramesMap[policyAppID];
-        document.body.removeChild(frame);
+        const web_engine_view = document.getElementById("webEngineView");
+        if (web_engine_view) {
+          web_engine_view.removeChild(frame);
+        }
       }
 
       const frame_name = `web_app_frame_${policyAppID}`;
       let web_app_frame =  document.createElement("iframe");
       web_app_frame.name = frame_name;
       web_app_frame.id = frame_name;
-      web_app_frame.className = "InvisibleFrame";
-      document.body.appendChild(web_app_frame);
+      web_app_frame.className = "WebEngineFrame";
+
+      const web_engine_view = document.getElementById("webEngineView");
+      if (web_engine_view) {
+        web_engine_view.appendChild(web_app_frame);
+      }
 
       SDL.SDLModel.webApplicationFramesMap[policyAppID] = web_app_frame;
 

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -1188,6 +1188,9 @@ SDL.SDLController = Em.Object.extend(
           }
 
           SDL.InfoController.getWebAppEntryPointPath(model.policyAppID, callback);
+        } else if (model.webEngineApp !== true && model.appType.indexOf('TESTING') >= 0) {
+          SDL.PopUp.create().appendTo('body')
+            .popupActivate("Only Web Engine apps with app type WEB_VIEW can be activated!");
         } else {
           FFW.BasicCommunication.ActivateApp(element.appID);
         }

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -1506,8 +1506,16 @@ SDL.SDLController = Em.Object.extend(
         windowCapability["systemCapability"]["displayCapabilities"][0]["windowCapabilities"][0]["windowID"] = windowID;
       }
       if(appID) {
+        var appModel = this.getApplicationModel(appID);
+        if (appModel && appModel.appType.indexOf('TESTING') >= 0 && windowType == "MAIN") {
+          delete windowCapability["systemCapability"]["displayCapabilities"][0]["windowCapabilities"][0]["textFields"];
+          delete windowCapability["systemCapability"]["displayCapabilities"][0]["windowCapabilities"][0]["imageFields"];
+          windowCapability["systemCapability"]["displayCapabilities"][0]["windowCapabilities"][0]["templatesAvailable"].push("WEB_VIEW");
+        }
+
         windowCapability["appID"] = appID;
       }
+
       return windowCapability;
     },
     /**

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -1021,7 +1021,10 @@ SDL.SDLController = Em.Object.extend(
       }
       if (app.webEngineApp && app.policyAppID in SDL.SDLModel.webApplicationFramesMap) {
         let frame = SDL.SDLModel.webApplicationFramesMap[app.policyAppID];
-        document.body.removeChild(frame);
+        const web_engine_view = document.getElementById("webEngineView");
+        if (web_engine_view) {
+          web_engine_view.removeChild(frame);
+        }
         delete SDL.SDLModel.webApplicationFramesMap[app.policyAppID];
       }
     },

--- a/app/controller/sdl/MediaController.js
+++ b/app/controller/sdl/MediaController.js
@@ -76,7 +76,27 @@ SDL.SDLMediaController = Em.Object.create(
       this.set('currentAppId', applicationModel.appID);
       // set active model
       SDL.SDLController.set('model', applicationModel);
+
+      if (SDL.SDLController.model.appType) {
+        for (var i = 0; i < SDL.SDLController.model.appType.length; i++) {
+          if (SDL.SDLController.model.appType[i] == 'NAVIGATION' ||
+              SDL.SDLController.model.appType[i] == 'PROJECTION') {
+            this.model.currentAudioModel.turnOnSDL();
+            SDL.BaseNavigationView.update();
+            SDL.States.goToStates('navigationApp.baseNavigation');
+            return;
+          }
+          if (SDL.SDLController.model.appType[i] == 'TESTING') {
+            // TODO(WEBENGINE)
+            SDL.InfoController.turnOnSDL();
+            SDL.States.goToStates('webViewApp');
+            return;
+          }
+        }
+      }
+
       this.model.currentAudioModel.turnOnSDL();
+      SDL.States.goToStates('media.sdlmedia');
     },
     /**
      * Restore current application to active state

--- a/app/controller/sdl/NonMediaController.js
+++ b/app/controller/sdl/NonMediaController.js
@@ -66,11 +66,29 @@ SDL.NonMediaController = Em.Object.create(
       this.set('currentAppId', applicationModel.appID);
       // set active model
       SDL.SDLController.set('model', applicationModel);
-      // send response
-      // FFW.BasicCommunication.ActivateApp( applicationModel.appID );
+
+      // go to SDL state
+      if (SDL.SDLController.model.appType) {
+        for (var i = 0; i < SDL.SDLController.model.appType.length; i++) {
+          if (SDL.SDLController.model.appType[i] == 'NAVIGATION' ||
+              SDL.SDLController.model.appType[i] == 'PROJECTION') {
+            SDL.InfoController.turnOnSDL();
+            SDL.BaseNavigationView.update();
+            SDL.States.goToStates('navigationApp.baseNavigation');
+            return;
+          }
+          if (SDL.SDLController.model.appType[i] == 'TESTING') {
+            // TODO(WEBENGINE)
+            SDL.InfoController.turnOnSDL();
+            SDL.States.goToStates('webViewApp');
+            return;
+          }
+        }
+      }
+
       // Go to SDL state
       SDL.InfoController.turnOnSDL();
-      //SDL.States.goToStates('info.nonMedia');
+      SDL.States.goToStates('info.nonMedia');
     },
     /**
      * Restore current application to active state

--- a/app/model/media/AudioModel.js
+++ b/app/model/media/AudioModel.js
@@ -343,21 +343,6 @@ SDL.AudioModel = Em.Object.extend({
       if (SDL.SDLController.model) {
         SDL.SDLController.model.set('active', true);
       }
-      /**
-       * Go to SDL state
-       */
-      if (SDL.SDLController.model.appType) {
-        for (var i = 0; i < SDL.SDLController.model.appType.length; i++) {
-          if (SDL.SDLController.model.appType[i] == 'NAVIGATION' ||
-              SDL.SDLController.model.appType[i] == 'PROJECTION') {
-            SDL.BaseNavigationView.update();
-            SDL.States.goToStates('navigationApp.baseNavigation');
-            return;
-          }
-        }
-      }
-
-      SDL.States.goToStates('media.sdlmedia');
     },
 
     /**

--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -1021,7 +1021,7 @@ SDL.SDLModelData = Em.Object.create(
               ],
               "imageTypeSupported": ["STATIC", "DYNAMIC"],
               "numCustomPresetsAvailable": 8,
-              "templatesAvailable": ["TEXT_WITH_GRAPHIC", "BUTTONS_WITH_GRAPHIC", "GRAPHIC_WITH_TEXT"],
+              "templatesAvailable": ["MEDIA", "NON-MEDIA", "ONSCREEN_PRESETS", "NAV_FULLSCREEN_MAP"],
               "buttonCapabilities": [
                 {
                   "longPressAvailable": true,

--- a/app/view/webEngine/webEngineView.js
+++ b/app/view/webEngine/webEngineView.js
@@ -30,14 +30,17 @@
  * @filesource app/view/webEngine/webEngineView.js
  * @version 1.0
  */
-SDL.WebEngineView = Em.ContainerView.create(
-    {
-      /** View Id */
+SDL.WebEngineView = Em.ContainerView.create({
       elementId: 'webEngineView',
       classNameBindings: [
         'SDL.States.webViewApp.active:active_state:inactive_state'
       ],
       childViews: [
-      ]
-    }
-  );
+        'TemplateTitleLabel'
+      ],
+
+      TemplateTitleLabel : SDL.Label.extend({
+        elementId: 'template_title_label',
+        contentBinding: 'SDL.SDLController.model.templateConfiguration.template'
+      })
+});

--- a/app/view/webEngine/webEngineView.js
+++ b/app/view/webEngine/webEngineView.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met: ·
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. · Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution. · Neither the name of the Ford Motor Company nor the
+ * names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @name SDL.WebEngineView
+ * @desc WebEngine view
+ * @category View
+ * @filesource app/view/webEngine/webEngineView.js
+ * @version 1.0
+ */
+SDL.WebEngineView = Em.ContainerView.create(
+    {
+      /** View Id */
+      elementId: 'webEngineView',
+      classNameBindings: [
+        'SDL.States.webViewApp.active:active_state:inactive_state'
+      ],
+      childViews: [
+      ]
+    }
+  );

--- a/capabilities/display_capabilities.js
+++ b/capabilities/display_capabilities.js
@@ -1673,5 +1673,25 @@ SDL.templateCapabilities = {
         "presetBankCapabilities": {
             "onScreenPresetsAvailable": false
         }
+    },
+    "WEB_VIEW": {
+        "displayCapabilities": {
+            "displayType": "GEN2_8_DMA",
+            "displayName": "SDL_HMI",
+            "graphicSupported": true,
+            "imageCapabilities": ["DYNAMIC", "STATIC"],
+            "templatesAvailable": ["MEDIA", "NON-MEDIA", "ONSCREEN_PRESETS", "NAV_FULLSCREEN_MAP", "WEB_VIEW"],
+            "screenParams": {
+                "resolution": {
+                    "resolutionWidth": 800,
+                    "resolutionHeight": 480
+                },
+                "touchEventAvailable": {
+                    "pressAvailable": true,
+                    "multiTouchAvailable": true,
+                    "doublePressAvailable": false
+                }
+            }
+        }
     }
 }

--- a/css/sdl.css
+++ b/css/sdl.css
@@ -1808,13 +1808,6 @@
     color: green
 }
 
-.InvisibleFrame {
-    position: absolute;
-    width: 0px;
-    height: 0px;
-    visibility: hidden;
-}
-
 #sdl_view_container {
     z-index: 501;
 }

--- a/css/webEngine.css
+++ b/css/webEngine.css
@@ -7,3 +7,18 @@
     width: 800px;
     height: 384px;
 }
+
+#webEngineView .WebEngineFrame {
+    position: absolute;
+    width: 800px;
+    height: 384px;
+}
+
+#webEngineView #template_title_label {
+    position: absolute;
+    top: 360px;
+    left: 322px;
+    width: 160px;
+    text-align: center;
+    z-index: 2;
+}

--- a/css/webEngine.css
+++ b/css/webEngine.css
@@ -1,0 +1,9 @@
+/* Web Engine related control styles */
+
+#webEngineView {
+    z-index: 2;
+    position: absolute;
+    top: 48px;
+    width: 800px;
+    height: 384px;
+}

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -223,6 +223,7 @@ FFW.UI = FFW.RPCObserver.create(
             let sendCapabilityUpdated = false;
             if("templateConfiguration" in request.params) {
               if (model.templateConfiguration.template !== request.params.templateConfiguration.template) {
+                model.templateConfiguration.template = request.params.templateConfiguration.template;
                 sendCapabilityUpdated = true;
               }
               if ("dayColorScheme" in  request.params.templateConfiguration

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="css/buttonControls.css"/>
     <link rel="stylesheet" type="text/css" href="css/general.css"/>
     <link rel="stylesheet" type="text/css" href="css/navigation.css"/>
+    <link rel="stylesheet" type="text/css" href="css/webEngine.css"/>
     <link rel="stylesheet" type="text/css" href="css/phone.css"/>
     <link rel="stylesheet" type="text/css" href="css/climate.css"/>
     <link rel="stylesheet" type="text/css" href="css/info.css"/>
@@ -249,6 +250,7 @@
 <script type="text/javascript"
         src="app/view/navigationApp/baseNavigationView.js"></script>
 <script type="text/javascript" src="app/view/navigationAppView.js"></script>
+<script type="text/javascript" src="app/view/webEngine/webEngineView.js"></script>
 
 <!-- home views -->
 <script type="text/javascript" src="app/view/home/controlButtons.js"></script>


### PR DESCRIPTION
Implements [SDL-0273](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0273-webengine-projection-mode.md)

This PR is **ready** for review.

### Testing Plan
Will be tested manually

### Summary
- Added webEngine apps view template
- Implemented logic of switching to WEB_VIEW template
- Move iframe element to webEngine view
- Update capabilities and template name update

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
