### PR TITLE
Fix Display mode is not applicable for POI list

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -1550,19 +1550,25 @@ SDL.SDLController = Em.Object.extend(
       return title;
     },
 
+    /**
+     * @description Callback for display image mode change.
+     */
     imageModeChanged: function() { 
-      if (SDL.SDLController.model) {
-        SDL.SDLController.model.setMode(SDL.SDLModel.data.imageMode);
-        length=SDL.OptionsView.commands.items.length;
-        var commands = SDL.SDLController.model.get('currentCommandsList');
-        for(var i=0;i<length;i++){
-          SDL.OptionsView.commands.items[i].type.prototype.setMode(SDL.SDLModel.data.imageMode);
-          if(commands[i].isTemplate){
-          SDL.OptionsView.commands.items[i].type.prototype.setMode(SDL.SDLModel.data.imageMode);
-          }
-        }
-        SDL.OptionsView.commands.refreshItems();
+      if (!SDL.SDLController.model) {
+        return;
       }
+
+      SDL.SDLController.model.setMode(SDL.SDLModel.data.imageMode);
+      var commands = SDL.SDLController.model.get('currentCommandsList');
+      const length = SDL.OptionsView.commands.items.length;
+      for(var i=0;i<length;i++){
+        SDL.OptionsView.commands.items[i].type.prototype.setMode(SDL.SDLModel.data.imageMode);
+        if(commands[i].isTemplate){
+          SDL.OptionsView.commands.items[i].type.prototype.setMode(SDL.SDLModel.data.imageMode);
+        }
+      }
+      SDL.OptionsView.commands.refreshItems();
+
     }.observes('SDL.SDLModel.data.imageMode')
   }
 );

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -1549,5 +1549,20 @@ SDL.SDLController = Em.Object.extend(
       }
       return title;
     },
+
+    imageModeChanged: function() { 
+      if (SDL.SDLController.model) {
+        SDL.SDLController.model.setMode(SDL.SDLModel.data.imageMode);
+        length=SDL.OptionsView.commands.items.length;
+        var commands = SDL.SDLController.model.get('currentCommandsList');
+        for(var i=0;i<length;i++){
+          SDL.OptionsView.commands.items[i].type.prototype.setMode(SDL.SDLModel.data.imageMode);
+          if(commands[i].isTemplate){
+          SDL.OptionsView.commands.items[i].type.prototype.setMode(SDL.SDLModel.data.imageMode);
+          }
+        }
+        SDL.OptionsView.commands.refreshItems();
+      }
+    }.observes('SDL.SDLModel.data.imageMode')
   }
 );

--- a/app/controlls/List.js
+++ b/app/controlls/List.js
@@ -152,8 +152,31 @@ SDL.List = Em.ContainerView.extend({
                 classNames: 'list-item',
 
                 classNameBindings: [
-                  'this.voiceOver'
+                  'this.voiceOver',
+                  'dayMode',
+                  'nightMode',
+                  'highLightedMode'
                 ],
+
+                dayMode:false,
+                nightMode:false,
+                highLightedMode:false,
+
+                setMode:function(mode) {
+                  this.set('dayMode',false);
+                  this.set('nightMode',false);
+                  this.set('highLightedMode',false);
+                  switch(mode){
+                    case SDL.SDLModel.data.imageModeList[0]:this.set('dayMode',true);break;
+                    case SDL.SDLModel.data.imageModeList[1]:this.set('nightMode',true);break;
+                    case SDL.SDLModel.data.imageModeList[2]:this.set('highLightedMode',true);break;
+                    default:this.set('dayMode',true);
+                  }
+                },
+                
+                imageModeDidChange: function() {
+                  this.setMode(SDL.SDLModel.data.imageMode);
+                }.observes('SDL.SDLModel.data.imageMode'),
 
                 // Dynamic property set
                 init: function() {

--- a/app/controlls/List.js
+++ b/app/controlls/List.js
@@ -163,10 +163,6 @@ SDL.List = Em.ContainerView.extend({
                 highLightedMode:false,
 
                 setMode:function(mode) {
-                  this.set('dayMode',false);
-                  this.set('nightMode',false);
-                  this.set('highLightedMode',false);
-
                   mode = SDL.SDLModel.data.imageModeList.includes(mode) ? mode : SDL.SDLModel.data.imageModeList[0];
                   this.set('dayMode', mode == SDL.SDLModel.data.imageModeList[0]);
                   this.set('nightMode', mode == SDL.SDLModel.data.imageModeList[1]);

--- a/app/controlls/List.js
+++ b/app/controlls/List.js
@@ -166,12 +166,11 @@ SDL.List = Em.ContainerView.extend({
                   this.set('dayMode',false);
                   this.set('nightMode',false);
                   this.set('highLightedMode',false);
-                  switch(mode){
-                    case SDL.SDLModel.data.imageModeList[0]:this.set('dayMode',true);break;
-                    case SDL.SDLModel.data.imageModeList[1]:this.set('nightMode',true);break;
-                    case SDL.SDLModel.data.imageModeList[2]:this.set('highLightedMode',true);break;
-                    default:this.set('dayMode',true);
-                  }
+
+                  mode = SDL.SDLModel.data.imageModeList.includes(mode) ? mode : SDL.SDLModel.data.imageModeList[0];
+                  this.set('dayMode', mode == SDL.SDLModel.data.imageModeList[0]);
+                  this.set('nightMode', mode == SDL.SDLModel.data.imageModeList[1]);
+                  this.set('highLightedMode', mode == SDL.SDLModel.data.imageModeList[2]);
                 },
                 
                 imageModeDidChange: function() {

--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -677,6 +677,12 @@ SDL.SDLModelData = Em.Object.create(
       'Night mode',
       'Highlighted mode'
     ],
+    /**
+     * @description Current display mode value 
+     * @type {String}
+     */
+    imageMode:'Highlighted mode', 
+
     windowType: {
       "MAIN": 0,
       "WIDGET": 1

--- a/app/view/home/controlButtons.js
+++ b/app/view/home/controlButtons.js
@@ -142,6 +142,7 @@ getCurrentDisplayModeClass: function() {
     default: return '';
   }
 },
+
 /**
  * HMI element Select with list of supported image mode
  */
@@ -149,37 +150,11 @@ getCurrentDisplayModeClass: function() {
     elementId: 'imageMode',
     classNames: 'imageModeSelect',
     contentBinding: 'SDL.SDLModel.data.imageModeList',
-    selection: 'Highlighted mode',
-    change:function(){
-      SDL.InfoAppsView.findNewApps.setMode(this.selection);
-      SDL.InfoAppsView.Asist911.setMode(this.selection);
-      SDL.InfoAppsView.vehicleHealthReport.setMode(this.selection);
-      SDL.InfoAppsView.getDeviceList.setMode(this.selection);
-      SDL.InfoView.leftMenu.items.servicesButton.setMode(this.selection);
-      SDL.InfoView.leftMenu.items.appsButton.setMode(this.selection);
-      SDL.InfoView.leftMenu.items.calendarButton.setMode(this.selection);
-      SDL.InfoView.leftMenu.items.goToCD.setMode(this.selection);
-      SDL.InfoView.leftMenu.items.travelLinkButton.setMode(this.selection);
-      SDL.InfoView.leftMenu.items.sdlButton.setMode(this.selection);
-      SDL.TurnByTurnView.nextTurnIconImage.setMode(this.selection);
-      SDL.TurnByTurnView.turnIconImage.setMode(this.selection);
-      SDL.InteractionChoicesView.set('imageMode',this.selection);
-      SDL.InteractionChoicesView.updateIcons();
-      if (SDL.SDLController.model) {
-        SDL.SDLController.model.setMode(this.selection);
-        length=SDL.OptionsView.commands.items.length;
-        var commands = SDL.SDLController.model.get('currentCommandsList');
-        for(var i=0;i<length;i++){
-          SDL.OptionsView.commands.items[i].type.prototype.setMode(this.selection);
-          if(commands[i].isTemplate){
-          SDL.OptionsView.commands.items[i].type.prototype.setMode(this.selection);
-          }
-        }
-        SDL.OptionsView.commands.refreshItems();
-      }
-    }
+    valueBinding: 'SDL.SDLModel.data.imageMode',
+    selection: 'Highlighted mode'
   }
 ),
+
 
   keyboard: SDL.Button.extend({
         classNames: ['keyboard', 'button'],

--- a/app/view/info/appsView.js
+++ b/app/view/info/appsView.js
@@ -172,6 +172,13 @@ SDL.InfoAppsView = Em.ContainerView.create({
     /** Items */
     items: new Array()
   }
-)
+),
+
+  imageModeChanged: function() { 
+    SDL.InfoAppsView.findNewApps.setMode(SDL.SDLModel.data.imageMode);
+    SDL.InfoAppsView.Asist911.setMode(SDL.SDLModel.data.imageMode);
+    SDL.InfoAppsView.vehicleHealthReport.setMode(SDL.SDLModel.data.imageMode);
+    SDL.InfoAppsView.getDeviceList.setMode(SDL.SDLModel.data.imageMode);
+  }.observes('SDL.SDLModel.data.imageMode')
 }
 );

--- a/app/view/info/appsView.js
+++ b/app/view/info/appsView.js
@@ -174,6 +174,9 @@ SDL.InfoAppsView = Em.ContainerView.create({
   }
 ),
 
+  /**
+   * @description Callback for display image mode change.
+   */
   imageModeChanged: function() { 
     SDL.InfoAppsView.findNewApps.setMode(SDL.SDLModel.data.imageMode);
     SDL.InfoAppsView.Asist911.setMode(SDL.SDLModel.data.imageMode);

--- a/app/view/infoView.js
+++ b/app/view/infoView.js
@@ -178,6 +178,9 @@ SDL.InfoView = Em.ContainerView.create(
               }
             ),
 
+            /**
+             * @description Callback for display image mode change.
+             */
             imageModeChanged: function() { 
               SDL.InfoView.leftMenu.items.servicesButton.setMode(SDL.SDLModel.data.imageMode);
               SDL.InfoView.leftMenu.items.appsButton.setMode(SDL.SDLModel.data.imageMode);

--- a/app/view/infoView.js
+++ b/app/view/infoView.js
@@ -176,7 +176,16 @@ SDL.InfoView = Em.ContainerView.create(
                 icon: 'images/media/ico_cd.png',
                 target: 'SDL.RCModulesController.currentAudioModel'
               }
-            )
+            ),
+
+            imageModeChanged: function() { 
+              SDL.InfoView.leftMenu.items.servicesButton.setMode(SDL.SDLModel.data.imageMode);
+              SDL.InfoView.leftMenu.items.appsButton.setMode(SDL.SDLModel.data.imageMode);
+              SDL.InfoView.leftMenu.items.calendarButton.setMode(SDL.SDLModel.data.imageMode);
+              SDL.InfoView.leftMenu.items.goToCD.setMode(SDL.SDLModel.data.imageMode);
+              SDL.InfoView.leftMenu.items.travelLinkButton.setMode(SDL.SDLModel.data.imageMode);
+              SDL.InfoView.leftMenu.items.sdlButton.setMode(SDL.SDLModel.data.imageMode);
+            }.observes('SDL.SDLModel.data.imageMode')
           }
         )
       }

--- a/app/view/navigationView.js
+++ b/app/view/navigationView.js
@@ -114,6 +114,9 @@ SDL.NavigationView = Em.ContainerView.create(
       }
     ),
 
+    /**
+     * @description Callback for display image mode change.
+     */
     imageModeChanged: function() { 
       SDL.NavigationView.POIButton.setMode(SDL.SDLModel.data.imageMode);
       SDL.NavigationView.navigate.setMode(SDL.SDLModel.data.imageMode);

--- a/app/view/navigationView.js
+++ b/app/view/navigationView.js
@@ -112,6 +112,11 @@ SDL.NavigationView = Em.ContainerView.create(
         action: 'setRoutes',
         target: 'SDL.NavigationController'
       }
-    )
+    ),
+
+    imageModeChanged: function() { 
+      SDL.NavigationView.POIButton.setMode(SDL.SDLModel.data.imageMode);
+      SDL.NavigationView.navigate.setMode(SDL.SDLModel.data.imageMode);
+    }.observes('SDL.SDLModel.data.imageMode')
   }
 );

--- a/app/view/sdl/shared/interactionChoicesView.js
+++ b/app/view/sdl/shared/interactionChoicesView.js
@@ -414,6 +414,9 @@ SDL.InteractionChoicesView = SDL.SDLAbstractView.create(
       );
     },
 
+    /**
+     * @description Callback for display image mode change.
+     */
     imageModeChanged: function() { 
       SDL.InteractionChoicesView.set('imageMode',SDL.SDLModel.data.imageMode);
       SDL.InteractionChoicesView.updateIcons();

--- a/app/view/sdl/shared/interactionChoicesView.js
+++ b/app/view/sdl/shared/interactionChoicesView.js
@@ -412,6 +412,11 @@ SDL.InteractionChoicesView = SDL.SDLAbstractView.create(
           self.deactivate('TIMED_OUT');
         }, timeout
       );
-    }
+    },
+
+    imageModeChanged: function() { 
+      SDL.InteractionChoicesView.set('imageMode',SDL.SDLModel.data.imageMode);
+      SDL.InteractionChoicesView.updateIcons();
+    }.observes('SDL.SDLModel.data.imageMode')
   }
 );

--- a/app/view/sdl/shared/turnByTurnView.js
+++ b/app/view/sdl/shared/turnByTurnView.js
@@ -249,6 +249,9 @@ SDL.TurnByTurnView = SDL.SDLAbstractView.create(
       }
     ),
 
+    /**
+     * @description Callback for display image mode change.
+     */
     imageModeChanged: function() { 
       SDL.TurnByTurnView.nextTurnIconImage.setMode(SDL.SDLModel.data.imageMode);
       SDL.TurnByTurnView.turnIconImage.setMode(SDL.SDLModel.data.imageMode);

--- a/app/view/sdl/shared/turnByTurnView.js
+++ b/app/view/sdl/shared/turnByTurnView.js
@@ -247,6 +247,11 @@ SDL.TurnByTurnView = SDL.SDLAbstractView.create(
           }
         )
       }
-    )
+    ),
+
+    imageModeChanged: function() { 
+      SDL.TurnByTurnView.nextTurnIconImage.setMode(SDL.SDLModel.data.imageMode);
+      SDL.TurnByTurnView.turnIconImage.setMode(SDL.SDLModel.data.imageMode);
+    }.observes('SDL.SDLModel.data.imageMode')
   }
 );


### PR DESCRIPTION
Implements/Fixes [#326](https://github.com/smartdevicelink/sdl_hmi/issues/326)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
In case of display mode value change there was no logic for changing display mode in navigation view. Besides that mechanics of DisplayMode selection view was changed: since now this control element just changes value of `SDL.SDLModel.data.imageMode` property and all interested observers are notified each time it changes to process such behavior with appropriate callback.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
