### PR TITLE
Fix error when display mode changed for non-media app

### DIFF
--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -291,10 +291,6 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
      */
   setMode:function(mode){
     if(this.isTemplate){
-      this.set('dayMode',false);
-      this.set('nightMode',false);
-      this.set('highLightedMode',false);
-
       mode = SDL.SDLModel.data.imageModeList.includes(mode) ? mode : SDL.SDLModel.data.imageModeList[0];
       this.set('dayMode', mode == SDL.SDLModel.data.imageModeList[0]);
       this.set('nightMode', mode == SDL.SDLModel.data.imageModeList[1]);

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -273,6 +273,22 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
   sdlSetMediaClockTimer: function() {
 
     return;
-  }
+  },
+
+    /**
+     * @description Method applies image mode view for model.
+     * @param {Number}
+     */
+  setMode:function(mode){
+    if(this.isTemplate){
+      switch(mode){
+        case SDL.SDLModel.data.imageModeList[0]:this.set('mode','day-mode');break;
+        case SDL.SDLModel.data.imageModeList[1]:this.set('mode','night-mode');break;
+        case SDL.SDLModel.data.imageModeList[2]:this.set('mode','high-lighted-mode');break;
+        default:this.set('mode','');
+      }
+    }
+    else this.set('mode','');
+  },
 }
 );

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -275,20 +275,31 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
     return;
   },
 
+  classNameBindings: [
+    'dayMode',
+    'nightMode',
+    'highLightedMode'
+  ],
+
+  dayMode:false,
+  nightMode:false,
+  highLightedMode:false,
+
     /**
      * @description Method applies image mode view for model.
      * @param {Number}
      */
   setMode:function(mode){
     if(this.isTemplate){
-      switch(mode){
-        case SDL.SDLModel.data.imageModeList[0]:this.set('mode','day-mode');break;
-        case SDL.SDLModel.data.imageModeList[1]:this.set('mode','night-mode');break;
-        case SDL.SDLModel.data.imageModeList[2]:this.set('mode','high-lighted-mode');break;
-        default:this.set('mode','');
-      }
+      this.set('dayMode',false);
+      this.set('nightMode',false);
+      this.set('highLightedMode',false);
+
+      mode = SDL.SDLModel.data.imageModeList.includes(mode) ? mode : SDL.SDLModel.data.imageModeList[0];
+      this.set('dayMode', mode == SDL.SDLModel.data.imageModeList[0]);
+      this.set('nightMode', mode == SDL.SDLModel.data.imageModeList[1]);
+      this.set('highLightedMode', mode == SDL.SDLModel.data.imageModeList[2]);
     }
-    else this.set('mode','');
   },
 }
 );


### PR DESCRIPTION
Implements/Fixes [#351](https://github.com/smartdevicelink/sdl_hmi/issues/351)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
There was no `setMode` method defined for NonMediaModel. This caused exception described in https://github.com/smartdevicelink/sdl_hmi/issues/351.
So appropriate method was added.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
