### PR TITLE
App permissions list fix

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -237,7 +237,6 @@ SDL.SettingsController = Em.Object.create(
      */
     permissionsFriendlyMessageUpdate: function(message) {
       SDL.SettingsController.simpleParseUserFriendlyMessageData(message);
-      SDL.States.goToStates('settings.policies.appPermissions');
     },
     updateSDL: function() {
       FFW.BasicCommunication.UpdateSDL();

--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -263,6 +263,9 @@ SDL.SettingsController = Em.Object.create(
       );
     },
     simpleParseUserFriendlyMessageData: function(messages, func) {
+      if(!messages) {
+        return;
+      }
       var tts = '',
         text = '';
       messages.forEach(

--- a/app/view/settings/policies/appPermissionsView.js
+++ b/app/view/settings/policies/appPermissionsView.js
@@ -90,6 +90,9 @@ SDL.AppPermissionsView = Em.ContainerView.create(
       SDL.AppPermissionsView.currentAppId = appID;
       this.appList.items = [];
       for (var i = 0; i < message.length; i++) {
+        if(!message[i].name){
+          continue;
+        }
         var text = ' - Undefined';
         text = (message[i].allowed === true) ? ' - Allowed' : ' - Not allowed';
         this.appList.items.push({


### PR DESCRIPTION
Fixes [#148](https://github.com/SmartDeviceLink/sdl_hmi/issues/148)

This PR is **ready** for review.

### Summary
Current PR contains an additional check for displaying propper application permissions.
Note: goToStates is removed from permissionsFriendlyMessageUpdate to prevent switching to app permissions after an application is activated.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
