### PR TITLE
Add check for FFW.CAN validity

### DIFF
--- a/app/model/media/AudioModels/MediaCDPlayer.js
+++ b/app/model/media/AudioModels/MediaCDPlayer.js
@@ -221,7 +221,9 @@ SDL.MediaCDPlayer = Em.Object.extend({
         'action': 'PREV'
       };
 
-      FFW.CAN.OnPlayerDetails(params);
+      if(FFW.CAN) {
+        FFW.CAN.OnPlayerDetails(params);
+      }
     },
 
     playTrackPress: function() {
@@ -244,7 +246,9 @@ SDL.MediaCDPlayer = Em.Object.extend({
         'action': self.isPlaying ? 'PLAY' : 'PAUSE'
       };
 
-      FFW.CAN.OnPlayerDetails(params);
+      if(FFW.CAN) {
+        FFW.CAN.OnPlayerDetails(params);
+      }
     },
 
     nextTrackPress: function() {
@@ -267,7 +271,9 @@ SDL.MediaCDPlayer = Em.Object.extend({
         'action': 'NEXT'
       };
 
-      FFW.CAN.OnPlayerDetails(params);
+      if(FFW.CAN) {
+        FFW.CAN.OnPlayerDetails(params);
+      }
     },
 
     shufflePress: function() {


### PR DESCRIPTION
Implements/Fixes 347

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
There was no check for FFW.CAN object validity. When mobile application is not connected FFW.CAN object is not created, so appropriate check added to `MediaCDPlayer` methods.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
