### PR TITLE
Fix setting timeout upon SliderView activation

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -656,9 +656,8 @@ SDL.ABSAppModel = Em.Object.extend(
      */
     onSlider: function(message) {
       SDL.SliderView.loadData(message);
-      SDL.SliderView.activate(this.appName, message.params.timeout);
-      // SDL.SliderView.setText(this.appName);
-      // SDL.SliderView.activate(message.params.timeout);
+      SDL.SliderView.setText(this.appName);
+      SDL.SliderView.activate(message.params.timeout);
     },
 
     /**


### PR DESCRIPTION
Implements/Fixes https://adc.luxoft.com/jira/browse/FORDTCN-6553

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Instead of passing only timeout value into `SDL.SliderView.activate` method there were 2 params passing: appName & timeout. Because of this actual timeout value was `SyncProxyTester` and not a numeric value. 
So now `SDL.SliderView.activate` method receives only timeout value.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
