### PR TITLE
SDL-0296 Add ability to show navi streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ I
 	* Click  the `System Request` button
     * Select the `PTU using in-vehicle modem` checkbox to enable the feature
 
+## Show navi/projection streaming
+ * Configure SDL ini file : `NamedVideoPipePath = video_stream_pipe`
+  
 ## Note
 SDL HMI utility is only for acquaintance with the SDL project.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ I
     * Select the `PTU using in-vehicle modem` checkbox to enable the feature
 
 ## Show navi/projection streaming
- * Configure SDL ini file : `NamedVideoPipePath = video_stream_pipe`
+ * Configure SDL ini file : `VideoStreamConsumer = pipe`
   
 ## Note
 SDL HMI utility is only for acquaintance with the SDL project.

--- a/README.md
+++ b/README.md
@@ -2,30 +2,10 @@
 
 HTML5 based utility to see how the SDL works. It connects via WebSocket to [SDL Core](https://github.com/smartdevicelink/sdl_core)
 
+
 # Getting Started
-A quick guide to installing, configuring, and running HMI.
 
-	1. run SmartDeviceLinkCore
-	2. run chromium-browser [root_of_cloned_sdl_hmi_repo/index.html]
-
-## Simulating signals for LOW_VOLTAGE feature
-In order to simulate UNIX signals used by the LOW_VOLTAGE feature, some additional setup is required
-
-	1. run `deploy_server.sh`
-	2. run the HMI normally
-	3. open the `Exit Application` menu, choose a signal from the menu and press `Send signal`
-
-## PTU With vehicle modem
-In order to get policy table updates using the vehicle modem, some additional setup is required
-
-	1. Run `deploy_server.sh`
-	2. Run the HMI normally
-	3. Click  the `System Request` button
-    4. Select the `PTU using in-vehicle modem` checkbox to enable the feature
-
-## A quick note about dependencies
 This project interacts with [SDL Core](https://github.com/smartdevicelink/sdl_core).
-
 To initialize the git submodules in this project after cloning, run the following commands:
 ```
 cd sdl_hmi
@@ -33,6 +13,28 @@ git submodule init
 git submodule update
 ```
 Alternatively, you can clone this repository with the --recurse-submodules flag.
+
+## Dependencies 
+ 
+ * ffmpeg : `sudo apt install ffmpeg`
+ * Python3,PIP : `sudo apt install python3, python3-pip`
+ * python-ffmpeg : `sudo python3 -m pip install ffmpeg-python`
+ * chroium-browser : `sudo apt install chromium-browser`
+
+## Start HMI
+A quick guide to installing, configuring, and running HMI.
+
+	1. run `deploy_server.sh`
+	2. run SmartDeviceLinkCore
+	2. run chromium-browser [root_of_cloned_sdl_hmi_repo/index.html]
+
+## Simulating signals for LOW_VOLTAGE feature
+I
+	* Open the `Exit Application` menu, choose a signal from the menu and press `Send signal`
+
+## PTU With vehicle modem
+	* Click  the `System Request` button
+    * Select the `PTU using in-vehicle modem` checkbox to enable the feature
 
 ## Note
 SDL HMI utility is only for acquaintance with the SDL project.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ A quick guide to installing, configuring, and running HMI.
 	2. run chromium-browser [root_of_cloned_sdl_hmi_repo/index.html]
 
 ## Simulating signals for LOW_VOLTAGE feature
-I
 	* Open the `Exit Application` menu, choose a signal from the menu and press `Send signal`
 
 ## PTU With vehicle modem

--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -546,6 +546,46 @@ SDL.InfoController = Em.Object.create(
         );
     },
 
+    
+    startStreamingAdapter: function(url) {
+      return new Promise( (resolve, reject) => {
+        let client = FFW.RPCSimpleClient;
+
+        let response_timer = setTimeout(function() {
+          Em.Logger.log('startVideoStreamingAdapter timout');
+          client.unsubscribeFromEvent('StartStreamingAdapter');
+          reject();
+        }, 10000);
+
+        let response_callback = function(params) {
+          Em.Logger.log('StreamingAdapter response');
+          clearTimeout(response_timer);
+          client.unsubscribeFromEvent('StartStreamingAdapter');
+
+          if (params.success == false) {
+            Em.Logger.log('StartStreamingAdapter failed');
+            reject();
+          }
+
+          Em.Logger.log('StartStreamingAdapter succesfully started');
+          resolve(params['stream_endpoint']);
+        }
+
+        let message = {
+          method: 'StartStreamingAdapter',
+          params: {
+            'url' : url
+          }
+        };
+
+        Em.Logger.log(`StartStreamingAdapter request`);
+        client.connect();
+        client.subscribeOnEvent('StartStreamingAdapter', response_callback);
+        client.send(message);
+      });
+    },
+
+
     /**
      * @description Switching on Application
      */

--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -558,7 +558,8 @@ SDL.InfoController = Em.Object.create(
         }, 10000);
 
         let response_callback = function(params) {
-          Em.Logger.log('StreamingAdapter response');
+          Em.Logger.log('StartStreamingAdapter response');
+
           clearTimeout(response_timer);
           client.unsubscribeFromEvent('StartStreamingAdapter');
 

--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -552,7 +552,8 @@ SDL.InfoController = Em.Object.create(
         let client = FFW.RPCSimpleClient;
 
         let response_timer = setTimeout(function() {
-          Em.Logger.log('startVideoStreamingAdapter timout');
+          Em.Logger.log('StartStreamingAdapter timeout');
+
           client.unsubscribeFromEvent('StartStreamingAdapter');
           reject();
         }, 10000);

--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -546,7 +546,11 @@ SDL.InfoController = Em.Object.create(
         );
     },
 
-    
+    /**
+     * @description Start converting streaming from SDL to the HTML5 video
+     * @param {String} url SDL streaming path (pipe or socket)
+     * @return {Promise} promice that resolves streaming URL with HTML5 video  
+     */
     startStreamingAdapter: function(url) {
       return new Promise( (resolve, reject) => {
         let client = FFW.RPCSimpleClient;

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -663,20 +663,24 @@ SDL.SDLModel = Em.Object.extend({
         null) {
 
         SDL.SDLModel.data.naviVideo = document.getElementById('html5Player');
-        SDL.SDLModel.data.naviVideo.src = SDL.SDLController.getApplicationModel(
+        var sdl_stream = SDL.SDLController.getApplicationModel(
           appID
         ).navigationStream;
 
-        var playPromise = SDL.SDLModel.data.naviVideo.play();
-        if (playPromise !== undefined) {
-          playPromise.then(_ => {
-            console.log('Video playback started OK');
-          })
-          .catch(error => {
-            console.log('Video playback start failed: ' + error);
-            SDL.SDLModel.data.naviVideo = null;
-          });
-        }
+        SDL.InfoController.startStreamingAdapter(sdl_stream).then(function(stream_endpoint) {
+          console.log('Adapter promice callback');
+          SDL.SDLModel.data.naviVideo.src = stream_endpoint
+          var playPromise = SDL.SDLModel.data.naviVideo.play();
+          if (playPromise !== undefined) {
+            playPromise.then(_ => {
+              console.log('Video playback started OK');
+            })
+            .catch(error => {
+              console.log('Video playback start failed: ' + error);
+              SDL.SDLModel.data.naviVideo = null;
+            });
+          }
+        });
       }
     },
 

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -668,7 +668,7 @@ SDL.SDLModel = Em.Object.extend({
         ).navigationStream;
 
         SDL.InfoController.startStreamingAdapter(sdl_stream).then(function(stream_endpoint) {
-          console.log('Adapter promice callback');
+          console.log('Starting video playback');
           SDL.SDLModel.data.naviVideo.src = stream_endpoint
           var playPromise = SDL.SDLModel.data.naviVideo.play();
           if (playPromise !== undefined) {

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -45,6 +45,8 @@ import pexpect.fdpexpect
 
 WEBSOCKET_PORT = 8081
 FILESERVER_PORT = 8082
+HTML5_STREAMING_HOST = "http://localhost"
+HTML5_STREAMING_PORT = 8085
 
 class HTTPHandler(SimpleHTTPRequestHandler):
     """This handler uses server.base_path instead of always using os.getcwd()"""
@@ -224,7 +226,16 @@ def handle_get_app_manifest_message(params):
 
 def handle_start_streaming_adapter(params):
 	print("-->Handle start ffmpeg adapter\r")
-	stream_endpoint = "http://localhost:8085"
+	stream_endpoint = "{}:{}".format(HTML5_STREAMING_HOST,HTML5_STREAMING_PORT)
+	if 'url' not in params :
+		print("'url' parameter missing")
+		response_msg = {
+			"method": "StartStreamingAdapter",
+			"params": {
+				"success": False,
+			}
+		}
+		return json.dumps(response_msg)
 	ffmpeg_process = ffmpeg.input(params['url']).output(stream_endpoint, vcodec="vp8", format="webm", listen=1, multiple_requests=1).run_async(pipe_stderr=True) 
 	print("Wait for data from SDL")
 	o = pexpect.fdpexpect.fdspawn(ffmpeg_process.stderr.fileno())

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -223,7 +223,7 @@ def handle_get_app_manifest_message(params):
 
 
 def handle_start_streaming_adapter(params):
-	print("-->Handle start gstreamer adapter\r")
+	print("-->Handle start ffmpeg adapter\r")
 	stream_endpoint = "http://localhost:8085"
 	ffmpeg_process = ffmpeg.input(params['url']).output(stream_endpoint, vcodec="vp8", format="webm", listen=1, multiple_requests=1).run_async(pipe_stderr=True) 
 	print("Wait for data from SDL")

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -229,7 +229,7 @@ def handle_start_streaming_adapter(params):
 	print("Wait for data from SDL")
 	o = pexpect.fdpexpect.fdspawn(ffmpeg_process.stderr.fileno())
 	o.expect("Input")
-	print("data from SDL available")
+	print("Data from SDL is available")
 	response_msg = {
 		"method": "StartStreamingAdapter",
 		"params": {


### PR DESCRIPTION
Use ffmpeg to proxy streaming from original SDL output (socket or
pipe) to webm http streaming on 8085 port

Put streaming from ffmpeg to video tag of the navi applicaiton
Part of https://adc.luxoft.com/jira/browse/FORDTCN-4167