### PR TITLE
Fix HMI sends "UI.SetGlobalProperties" and "TTS.SetGlobalProperties" responses with empty info message

### DIFF
--- a/ffw/TTSRPC.js
+++ b/ffw/TTSRPC.js
@@ -202,14 +202,18 @@ FFW.TTS = FFW.RPCObserver.create(
           // processed."); this.errorResponsePull[request.id] = null;  return;
           // } }
           resultCode = FFW.RPCHelper.getCustomResultCode(request.params.appID, 'ttsSetGlobalProperties');
+          let info = null;
           
           if(FFW.RPCHelper.isSuccessResultCode(resultCode)){
             SDL.SDLModel.setProperties(request.params);
+          } else {
+            info = 'Erroneous response is assigned by settings';
           }
           this.sendTTSResult(
             resultCode,
             request.id,
-            request.method
+            request.method,
+            info
           );
           break;
         }
@@ -374,7 +378,7 @@ FFW.TTS = FFW.RPCObserver.create(
      * @param {String}
      *            method
      */
-    sendTTSResult: function(resultCode, id, method) {
+    sendTTSResult: function(resultCode, id, method, info) {
       if (this.errorResponsePull[id]) {
         this.sendError(
           this.errorResponsePull[id].code, id, method,
@@ -397,7 +401,7 @@ FFW.TTS = FFW.RPCObserver.create(
         };
         this.sendMessage(JSONMessage);
       } else {
-        this.sendError(resultCode, id, method, '');
+        this.sendError(resultCode, id, method, info);
       }
     },
     /*

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -274,12 +274,16 @@ FFW.UI = FFW.RPCObserver.create(
             // not processed."); this.errorResponsePull[request.id] = null;
             // return; } }
           resultCode = FFW.RPCHelper.getCustomResultCode(request.params.appID, 'uiSetGlobalProperties');
+          let info = null;
           
           if(FFW.RPCHelper.isSuccessResultCode(resultCode)){
             SDL.SDLModel.setProperties(request.params);
+          } else {
+            info = 'Erroneous response is assigned by settings';
           }
+
           this.sendUIResult(
-            resultCode, request.id, request.method
+            resultCode, request.id, request.method, info
             );
             break;
           }
@@ -1638,7 +1642,7 @@ FFW.UI = FFW.RPCObserver.create(
         };
         this.sendMessage(JSONMessage);
       } else {
-        this.sendError(resultCode, id, method, '');
+        this.sendError(resultCode, id, method, info);
       }
     },
     /**


### PR DESCRIPTION
Fixes (https://adc.luxoft.com/jira/browse/FORDTCN-6936)

This PR is **not ready** for review.

### Testing Plan
Covered by manual testing plan
### Summary
Was changed implementation in `'TTS.SetGlobalProperties'` and `'UI.SetGlobalProperties'`, added parameter `'info'` to corresponding RPC.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
