### PR TITLE
fix HMI sends SetGlobalProperties response with info null

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1654,8 +1654,7 @@ FFW.UI = FFW.RPCObserver.create(
           'id': id,
           'result': {
             'code': resultCode, // type (enum) from SDL protocol
-            'method': method,
-            'info': info
+            'method': method            
           }
         };
         this.sendMessage(JSONMessage);


### PR DESCRIPTION
Fixes [#7136](https://adc.luxoft.com/jira/browse/FORDTCN-7136)

This PR is **not ready** for review.

### Testing Plan
Covered by manual testing plan

### Summary
Changed: HMI does not add info part in SetGlobalProperties response message
 in "SUCCESS" case selected in RPC  Control

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
