### PR TITLE
Use reference to object inside of timer callback

### DIFF
--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -178,7 +178,7 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       var self = this;
       this.timer = setTimeout( function() {
           self.set( 'activate', false );
-          this.set('endTime', null);
+          self.set('endTime', null);
           FFW.Navigation.sendNavigationResult(
             SDL.SDLModel.data.resultCode.SUCCESS,
             message.id,


### PR DESCRIPTION
Implements/Fixes 404

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Instead of reference to object which method should be called, a this reference was used, that was a reference to timer callback.
So right one reference is used instead.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
