### PR TITLE
Added SubtleAlert RPC missing text fields in UI.GetCapabilities response

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -853,6 +853,24 @@ FFW.UI = FFW.RPCObserver.create(
                       'characterSet': 'UTF_8',
                       'width': 500,
                       'rows': 1
+                    },
+                    {
+                      'name': 'subtleAlertText1',
+                      'characterSet': 'UTF_8',
+                      'width': 500,
+                      'rows': 1
+                    },
+                    {
+                      'name': 'subtleAlertText2',
+                      'characterSet': 'UTF_8',
+                      'width': 500,
+                      'rows': 1
+                    },
+                    {
+                      'name': 'subtleAlertSoftButtonText',
+                      'characterSet': 'UTF_8',
+                      'width': 500,
+                      'rows': 1
                     }
                   ],
                   'imageFields': [
@@ -1002,6 +1020,18 @@ FFW.UI = FFW.RPCObserver.create(
                     },
                     {
                       'name': 'alertIcon',
+                      'imageTypeSupported': [
+                        'GRAPHIC_BMP',
+                        'GRAPHIC_JPEG',
+                        'GRAPHIC_PNG'
+                      ],
+                      'imageResolution': {
+                        'resolutionWidth': 105,
+                        'resolutionHeight': 65
+                      }
+                    },
+                    {
+                      'name': 'subtleAlertIcon',
                       'imageTypeSupported': [
                         'GRAPHIC_BMP',
                         'GRAPHIC_JPEG',


### PR DESCRIPTION
Fixes (.....smartdevicelink/sdl_hmi/issues/'413')

This PR is **ready** for review.

### Testing Plan
Covered by manual testing plan

### Summary
Were added missing SubtleAlert RPC related text fields and image fields in UI.GetCapabilities response.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
