### PR TITLE
 Added SubtleAlert RPC missing fields in OnSystemCapabilityUpdated notification on app registration

### DIFF
--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -900,6 +900,24 @@ SDL.SDLModelData = Em.Object.create(
                   "characterSet": "UTF_8",
                   "width": 500,
                   "rows": 1
+                },
+                {
+                  "name": "subtleAlertText1",
+                  "characterSet": "UTF_8",
+                  "width": 500,
+                  "rows": 1
+                },
+                {
+                  "name": "subtleAlertText2",
+                  "characterSet": "UTF_8",
+                  "width": 500,
+                  "rows": 1
+                },
+                {
+                  "name": "subtleAlertSoftButtonText",
+                  "characterSet": "UTF_8",
+                  "width": 500,
+                  "rows": 1
                 }
               ],
               'imageFields': [
@@ -1049,6 +1067,18 @@ SDL.SDLModelData = Em.Object.create(
                 },
                 {
                   'name': 'alertIcon',
+                  'imageTypeSupported': [
+                    'GRAPHIC_BMP',
+                    'GRAPHIC_JPEG',
+                    'GRAPHIC_PNG'
+                  ],
+                  'imageResolution': {
+                    'resolutionWidth': 105,
+                    'resolutionHeight': 65
+                  }
+                },
+                {
+                  'name': 'subtleAlertIcon',
                   'imageTypeSupported': [
                     'GRAPHIC_BMP',
                     'GRAPHIC_JPEG',


### PR DESCRIPTION
Fixes [sdl_hmi/issues/429]

This PR is **not ready** for review.

### Testing Plan
Covered by manual testing plan

### Summary
Were added missing SubtleAlert RPC related text fields and image fields in OnSystemCapabilityUpdated notification on app registration.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
