### PR TITLE
Keyboard property related fixes

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -1212,25 +1212,24 @@ SDL.SDLController = Em.Object.extend(
     onKeyboardChanges: function() {
       if (null !== SDL.SDLModel.data.keyboardInputValue) {
         var str = SDL.SDLModel.data.keyboardInputValue;
+
+        let mode = 'RESEND_CURRENT_ENTRY';
         if (SDL.SDLController.model &&
-          SDL.SDLController.model.globalProperties.keyboardProperties.keypressMode) {
-          switch (SDL.SDLController.model.globalProperties.keyboardProperties.keypressMode) {
-            case 'SINGLE_KEYPRESS':
-            {
-              FFW.UI.OnKeyboardInput(str.charAt(str.length - 1), 'KEYPRESS');
-              break;
-            }
-            case 'QUEUE_KEYPRESS':
-            {
-              break;
-            }
-            case 'RESEND_CURRENT_ENTRY':
-            {
-              if (str) {
-                FFW.UI.OnKeyboardInput(str, 'KEYPRESS');
-              }
-              break;
-            }
+            SDL.SDLController.model.globalProperties.keyboardProperties.keypressMode) {
+          mode = SDL.SDLController.model.globalProperties.keyboardProperties.keypressMode;
+        }
+
+        switch (mode) {
+          case 'SINGLE_KEYPRESS': {
+            FFW.UI.OnKeyboardInput(str.charAt(str.length - 1), 'KEYPRESS');
+            break;
+          }
+          case 'QUEUE_KEYPRESS': {
+            break;
+          }
+          case 'RESEND_CURRENT_ENTRY': {
+            FFW.UI.OnKeyboardInput(str, 'KEYPRESS');
+            break;
           }
         }
       }

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -502,6 +502,46 @@ SDL.ABSAppModel = Em.Object.extend(
       this.get('softButtons').pushObjects(buttons);
     },
     /**
+     * @description Set app global properties to default
+     */
+    resetGlobalProperties: function() {
+      this.set('globalProperties', Em.Object.create());
+      this.set('globalProperties.helpPrompt', []);
+      this.set('globalProperties.timeoutPrompt', []);
+      this.set('globalProperties.menuIcon', Em.Object.create());
+      this.resetKeyboardGlobalProperties('QWERTY');
+    },
+    /**
+     * @description Set app keyboard global properties to default
+     * @param {String} default_layout keyboard layout by default
+     */
+    resetKeyboardGlobalProperties: function(default_layout) {
+      this.set('maskInputCharactersUserChoice', false);
+      this.set('globalProperties.keyboardProperties', Em.Object.create());
+      this.set('globalProperties.keyboardProperties.keyboardLayout', default_layout);
+      this.set('globalProperties.keyboardProperties.keypressMode', 'RESEND_CURRENT_ENTRY');
+      this.set('globalProperties.keyboardProperties.maskInputCharacters', 'DISABLE_INPUT_KEY_MASK');
+      this.set('globalProperties.keyboardProperties.customizeKeys', []);
+      this.set('globalProperties.keyboardProperties.limitedCharacterList', []);
+    },
+    /**
+     * @description Performs actions on HMI level resumption start
+     */
+    startHmiLevelResumption: function() {
+      this.set('isHmiLevelResumption', true);
+    },
+    /**
+     * @description Performs actions on HMI level resumption finish
+     */
+    finishHmiLevelResumption: function() {
+      this.set('isHmiLevelResumption', false);
+
+      if (this.globalProperties.keyboardProperties.maskInputCharacters == 'USER_CHOICE_INPUT_KEY_MASK') {
+        // To trigger notification sending after app is activated and masking button is active
+        SDL.KeyboardController.maskInputCharacters();
+      }
+    },
+    /**
      * Add command to list
      *
      * @param {Object}

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -950,32 +950,53 @@ SDL.SDLModel = Em.Object.extend({
    *
    * @param {Object}
    *            message Object with parameters come from SDLCore.
+   * @returns {String} result code
    */
   setProperties: function(params) {
-    function mergeKeyboardProperties(properties) {
-      for (var name in properties) {
-        SDL.SDLController.getApplicationModel(params.appID).
-            set('globalProperties.keyboardProperties.' + name,
-              properties[name]
-            );
-      }
-    }
-    if (SDL.SDLController.getApplicationModel(params.appID)) {
-      for (var i in params) {
-        if (i === "appID") {
-          continue;
-        }
-        else if (i === 'keyboardProperties') {
-          mergeKeyboardProperties(params[i]);
-          SDL.KeyboardController.disableButtons();
-        } else {
-          SDL.SDLController.getApplicationModel(params.appID).
-              set('globalProperties.' + i, params[i]);
-        }
-      }
-    } else {
+    let model = SDL.SDLController.getApplicationModel(params.appID);
+    if (!model) {
       console.error('CriticalError! No app registered with current appID!');
+      return SDL.SDLModel.data.resultCode.APPLICATION_NOT_REGISTERED;
     }
+
+    let unsupported_custom_keys_found = false;
+
+    function mergeKeyboardProperties(properties) {
+      model.resetKeyboardGlobalProperties(
+        model.get('globalProperties.keyboardProperties.keyboardLayout')
+      );
+
+      for (var name in properties) {
+        if (name === 'customizeKeys') {
+          const unsupported_keys = SDL.KeyboardController.get('unsupportedKeyboardSymbols');
+          unsupported_keys.forEach((key) => {
+            if (properties[name].includes(key)) {
+              unsupported_custom_keys_found = true;
+            }
+          });
+        }
+
+        model.set('globalProperties.keyboardProperties.' + name, properties[name]);
+      }
+    }
+
+    for (var i in params) {
+      if (i === "appID") {
+        continue;
+      }
+      else if (i === 'keyboardProperties') {
+        mergeKeyboardProperties(params[i]);
+        SDL.KeyboardController.disableButtons();
+      } else {
+        model.set('globalProperties.' + i, params[i]);
+      }
+    }
+
+    if (unsupported_custom_keys_found) {
+      return SDL.SDLModel.data.resultCode.WARNINGS;
+    }
+
+    return SDL.SDLModel.data.resultCode.SUCCESS;
   },
 
   /**

--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -1242,10 +1242,6 @@ SDL.SDLModelData = Em.Object.create(
                       "numConfigurableKeys": 3
                     },
                     {
-                      "keyboardLayout": "QWERTZ",
-                      "numConfigurableKeys": 0
-                    },
-                    {
                       "keyboardLayout": "AZERTY",
                       "numConfigurableKeys": 4
                     },

--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -82,15 +82,6 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
     this.set('VRCommands', []);
     this.set('tbtActivate', false);
     this.set('isPlaying', true);
-    this.set('globalProperties', Em.Object.create());
-    this.set('globalProperties.helpPrompt', []);
-    this.set('globalProperties.timeoutPrompt', []);
-    this.set('globalProperties.keyboardProperties', Em.Object.create());
-    this.set('globalProperties.keyboardProperties.keyboardLayout', 'QWERTY');
-    this.set('globalProperties.keyboardProperties.limitedCharacterList', []);
-    this.set('globalProperties.keyboardProperties.maskInputCharacters', 'DISABLE_INPUT_KEY_MASK');
-    this.set('globalProperties.keyboardProperties.customizeKeys', []);
-    this.set('globalProperties.menuIcon', Em.Object.create());
 
     this.set('commandsList', {'top': []});
     this.set('softButtons', []);
@@ -99,6 +90,8 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
     this.set('backgroundWindows', []);
     this.set('activeWindows', []);
     this.set('unregisteringInProgress', false);
+
+    this.resetGlobalProperties();
   },
 
   /**

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -84,15 +84,6 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
     this.set('initialColorScheme.displayLayout', this.displayLayout);
     this.set('VRCommands', []);
     this.set('tbtActivate', false);
-    this.set('globalProperties', Em.Object.create());
-    this.set('globalProperties.helpPrompt', []);
-    this.set('globalProperties.timeoutPrompt', []);
-    this.set('globalProperties.keyboardProperties', Em.Object.create());
-    this.set('globalProperties.keyboardProperties.keyboardLayout', 'QWERTY');
-    this.set('globalProperties.keyboardProperties.limitedCharacterList', []);
-    this.set('globalProperties.keyboardProperties.maskInputCharacters', 'DISABLE_INPUT_KEY_MASK');
-    this.set('globalProperties.keyboardProperties.customizeKeys', []);
-    this.set('globalProperties.menuIcon', Em.Object.create());
 
     this.set('inactiveWindows', []);
     this.set('backgroundWindows', []);
@@ -100,6 +91,8 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
 
     this.set('commandsList', {'top': []});
     this.set('softButtons', []);
+
+    this.resetGlobalProperties();
   },
 
   /**

--- a/app/view/sdl/shared/keyboard.js
+++ b/app/view/sdl/shared/keyboard.js
@@ -124,7 +124,8 @@ SDL.Keyboard = SDL.SDLAbstractView.create(
             action: 'inputChanges',
             target: 'SDL.KeyboardController',
             templateName: 'icon',
-            icon: 'images/common/search.png'
+            icon: 'images/common/search.png',
+            onDown: false
           }
         ),
         input: Ember.TextField.extend(

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -634,6 +634,9 @@ FFW.BasicCommunication = FFW.RPCObserver
             );
           }
           if (request.method == 'BasicCommunication.ActivateApp') {
+            let model = SDL.SDLController.getApplicationModel(request.params.appID);
+            model.startHmiLevelResumption();
+
             if (!request.params.level || request.params.level == 'FULL') {
               if (SDL.SDLController.model &&
                 SDL.SDLController.model.appID != request.params.appID) {
@@ -643,14 +646,11 @@ FFW.BasicCommunication = FFW.RPCObserver
                 SDL.SDLModel.data.stateLimited = null;
                 SDL.SDLModel.data.set('limitedExist', false);
               }
-              SDL.SDLController.getApplicationModel(request.params.appID).level
-                = 'FULL';
-              SDL.SDLController.getApplicationModel(request.params.appID)
-                .turnOnSDL(request.params.appID);
+              model.level = 'FULL';
+              model.turnOnSDL(request.params.appID);
               SDL.VRPopUp.updateVR();
             } else if (request.params.level === 'LIMITED') {
-              SDL.SDLController.getApplicationModel(request.params.appID).level
-                = 'LIMITED';
+              model.level = 'LIMITED';
               SDL.VRPopUp.updateVR();
               if (SDL.SDLController.model &&
                 SDL.SDLController.model.appID === request.params.appID) {
@@ -658,8 +658,7 @@ FFW.BasicCommunication = FFW.RPCObserver
               }
               SDL.InfoAppsView.showAppList();
             } else if (request.params.level === 'NONE') {
-              SDL.SDLController.getApplicationModel(request.params.appID).level
-                = 'NONE';
+              model.level = 'NONE';
               SDL.VRPopUp.updateVR();
               if (SDL.SDLController.model &&
                 SDL.SDLController.model.appID === request.params.appID) {
@@ -667,8 +666,7 @@ FFW.BasicCommunication = FFW.RPCObserver
               }
               SDL.InfoAppsView.showAppList();
             } else if (request.params.level === 'BACKGROUND') {
-              SDL.SDLController.getApplicationModel(request.params.appID).level
-                = 'BACKGROUND';
+              model.level = 'BACKGROUND';
               SDL.VRPopUp.updateVR();
               if (SDL.SDLController.model &&
                 SDL.SDLController.model.appID === request.params.appID) {
@@ -679,6 +677,8 @@ FFW.BasicCommunication = FFW.RPCObserver
             this.sendBCResult(
               SDL.SDLModel.data.resultCode.SUCCESS, request.id, request.method
             );
+
+            model.finishHmiLevelResumption();
           }
           if (request.method == 'BasicCommunication.CloseApplication') {
             SDL.SDLController.getApplicationModel(request.params.appID).level

--- a/ffw/TTSRPC.js
+++ b/ffw/TTSRPC.js
@@ -172,7 +172,7 @@ FFW.TTS = FFW.RPCObserver.create(
           let info = null;
 
           if(FFW.RPCHelper.isSuccessResultCode(resultCode)){
-            SDL.SDLModel.setProperties(request.params);
+            resultCode = SDL.SDLModel.setProperties(request.params);
           } else {
             info = 'Erroneous response is assigned by settings';
           }

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -273,7 +273,7 @@ FFW.UI = FFW.RPCObserver.create(
           let info = null;
           
           if(FFW.RPCHelper.isSuccessResultCode(resultCode)){
-            SDL.SDLModel.setProperties(request.params);
+            resultCode = SDL.SDLModel.setProperties(request.params);
 
             var imageList = [];
             if(request.params.menuIcon) {


### PR DESCRIPTION
Fixes FORDTCN-11032 + FORDTCN-11033 + all other cases from FORDTCN-10956

This PR is **ready** for review.

### Testing Plan
Will be tested manually

### Summary
Fixes for:
1. HMI does not reset previously defined 'KeyboardProperties' to default values for keyboardInputMask and customizeKeys
https://adc.luxoft.com/jira/secure/XrayExecuteTest!default.jspa?testExecIssueKey=FORDTCN-10956&testIssueKey=FORDTCN-10949
2. HMI sends redundant UI.OnKeyboardInput" {"event":"INPUT_KEY_MASK_ENABLED"}}
https://adc.luxoft.com/jira/secure/XrayExecuteTest!default.jspa?testExecIssueKey=FORDTCN-10956&testIssueKey=FORDTCN-10987
3. [HMI] Improvement in QWERTZ for “If HMI does not provide configurable keys in root level of keyboards, the system should return Zero in number of configurable keys.”
4. Set default action for keypressMode
```
 <param name="keypressMode" type="Common.KeypressMode" mandatory="false" >
    <description>
        Desired keypress mode.
        If omitted, this value will be set to RESEND_CURRENT_ENTRY.
    </description>
```

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
