### PR TITLE
Feature/sdl 0293 enable oem exclusive apps support

### DIFF
--- a/app/StateManager.js
+++ b/app/StateManager.js
@@ -212,6 +212,14 @@ var StateManager = Em.StateManager.extend(
                 }
               }
             ),
+            vehicleTypeEditor: Em.State.create(
+              {
+                enter: function() {
+                  this._super();
+                  SDL.SettingsController.updateVehicleTypeValues(SDL.SDLVehicleInfoModel.vehicleType);
+                }
+              }
+            ),
             deviceConfig: Em.State.create(
               {
                 enter: function() {

--- a/app/StateManager.js
+++ b/app/StateManager.js
@@ -198,11 +198,12 @@ var StateManager = Em.StateManager.extend(
                 }
               }
             ),
-            ccpuEditor: Em.State.create(
+            versionsEditor: Em.State.create(
               {
                 enter: function() {
                   this._super();
                   SDL.SettingsController.set('editedCcpuVersionValue', SDL.SDLModel.data.ccpuVersion);
+                  SDL.SettingsController.set('editedHardwareVersionValue', SDL.SDLModel.data.hardwareVersion);
                 }
               }
             ),

--- a/app/StateManager.js
+++ b/app/StateManager.js
@@ -203,7 +203,12 @@ var StateManager = Em.StateManager.extend(
                 enter: function() {
                   this._super();
                   SDL.SettingsController.set('editedCcpuVersionValue', SDL.SDLModel.data.ccpuVersion);
-                  SDL.SettingsController.set('editedHardwareVersionValue', SDL.SDLModel.data.hardwareVersion);
+                  if (SDL.SDLModel.data.hardwareVersion != null) {
+                    SDL.SettingsController.set('editedHardwareVersionValue', SDL.SDLModel.data.hardwareVersion);
+                    SDL.SettingsController.set('hardwareVersionEditingEnabled', true);
+                  } else {
+                    SDL.SettingsController.set('hardwareVersionEditingEnabled', false);
+                  }
                 }
               }
             ),

--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -84,6 +84,11 @@ SDL.SettingsController = Em.Object.create(
      */
     hardwareVersionEditingEnabled: true,
 
+    /**
+     * @description Map of vehicle type data displayed in user inputs
+     */
+    editedVehicleType: {},
+
     onState: function(event) {
       if(SDL.States.currentState.name === 'rpcconfig'){
         FFW.RPCHelper.setCurrentAppID(null);
@@ -623,7 +628,57 @@ SDL.SettingsController = Em.Object.create(
       SDL.SDLModel.data.hardwareVersion = this.hardwareVersionEditingEnabled ?
         this.editedHardwareVersionValue : null;
 
-      Em.Logger.log("New settings have been applied");
+      Em.Logger.log("New system version settings have been applied");
+    },
+
+    /**
+     * @description Getter for all available vehicle type data and corresponding controls
+     */
+    getVehicleTypeCheckboxes: function() {
+      return [
+        { checkbox: SDL.VehicleTypeEditorView.vehicleMakeCheckBox, property: 'make' },
+        { checkbox: SDL.VehicleTypeEditorView.vehicleModelCheckBox, property: 'model' },
+        { checkbox: SDL.VehicleTypeEditorView.vehicleYearCheckBox, property: 'modelYear' },
+        { checkbox: SDL.VehicleTypeEditorView.vehicleTrimCheckBox, property: 'trim' }
+      ];
+    },
+
+    /**
+     * @description Applies edited by user vehicle data settings to internal data
+     */
+    applyNewVehicleTypeValues: function() {
+      let setNewVehicleTypeValue = (checkbox, property) => {
+        if (checkbox.checked) {
+          SDL.SDLVehicleInfoModel.set('vehicleType.' + property, this.editedVehicleType[property]);
+        } else {
+          SDL.SDLVehicleInfoModel.set('vehicleType.' + property, null);
+        }
+      };
+
+      this.getVehicleTypeCheckboxes().forEach( (item) => {
+        setNewVehicleTypeValue(item.checkbox, item.property);
+      });
+
+      Em.Logger.log("New vehicle type have been applied");
+    },
+
+    /**
+     * @description Updated UI controls and values according to internal data values
+     * @param {Object} new_values internal data values structure
+     */
+    updateVehicleTypeValues: function(new_values) {
+      let setNewVehicleTypeValue = (checkbox, property) => {
+        if (new_values[property] !== null) {
+          this.set('editedVehicleType.' + property, new_values[property]);
+          checkbox.set('checked', true);
+        } else {
+          checkbox.set('checked', false);
+        }
+      };
+
+      this.getVehicleTypeCheckboxes().forEach( (item) => {
+        setNewVehicleTypeValue(item.checkbox, item.property);
+      });
     },
 
     /**

--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -74,6 +74,16 @@ SDL.SettingsController = Em.Object.create(
      */
     editedCcpuVersionValue: "",
 
+    /**
+     * @description Value of hardware version displayed in user input
+     */
+    editedHardwareVersionValue: "",
+
+    /**
+     * @description Flag to enable/disable hardware version text field
+     */
+    hardwareVersionEditingEnabled: true,
+
     onState: function(event) {
       if(SDL.States.currentState.name === 'rpcconfig'){
         FFW.RPCHelper.setCurrentAppID(null);
@@ -606,10 +616,14 @@ SDL.SettingsController = Em.Object.create(
     },
 
     /**
-     * @description Saves new CCPU version value from user input
+     * @description Saves new CCPU and hardware version values from user input
      */
-    applyNewCcpuVersionValue: function() {
+    applyNewVersionValues: function() {
       SDL.SDLModel.data.ccpuVersion = this.editedCcpuVersionValue;
+      SDL.SDLModel.data.hardwareVersion = this.hardwareVersionEditingEnabled ?
+        this.editedHardwareVersionValue : null;
+
+      Em.Logger.log("New settings have been applied");
     },
 
     /**

--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -653,6 +653,11 @@ SDL.SDLModelData = Em.Object.create(
      */
     ccpuVersion: '12345_US',
     /**
+     * Hardware version value
+     * @type {String}
+     */
+    hardwareVersion: '123.456.7890',
+    /**
      * Parameter describes if performInteraction session was started on HMI
      * this flag set to true when UI.PerformInteraction request came on HMI
      * and set to false when HMI send response to SDL Core on

--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -357,7 +357,13 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
      * @type {Number}
      */
     getVehicleType: function(id) {
-      FFW.VehicleInfo.GetVehicleTypeResponse(this.vehicleType, id);
+      let data_to_send = {};
+      Object.keys(this.vehicleType).forEach((key) => {
+        if (this.vehicleType[key] !== null) {
+          data_to_send[key] = this.vehicleType[key];
+        }
+      });
+      FFW.VehicleInfo.GetVehicleTypeResponse(data_to_send, id);
     },
     /**
      * SDL VehicleInfo.GetDTCs handler fill data for response about vehicle

--- a/app/view/settings/policies/systemVersionsEditorView.js
+++ b/app/view/settings/policies/systemVersionsEditorView.js
@@ -24,24 +24,26 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-SDL.CcpuEditorView = Em.ContainerView.create(
+SDL.SystemVersionsEditorView = Em.ContainerView.create(
     {
-      elementId: 'policies_settings_ccpu_editor_view',
+      elementId: 'policies_settings_system_versions_editor_view',
       classNames: 'in_settings_separate_view',
       classNameBindings: [
-        'SDL.States.settings.policies.ccpuEditor.active:active_state:inactive_state'
+        'SDL.States.settings.policies.versionsEditor.active:active_state:inactive_state'
       ],
       childViews: [
-        'ccpuTitle',
+        'versionsTitle',
         'backButton',
         'ccpuVersionLabel',
         'ccpuVersionInput',
+        'hardwareVersionLabel',
+        'hardwareVersionInput',
         'applyButton'
       ],
-      ccpuTitle: SDL.Label.extend(
+      versionsTitle: SDL.Label.extend(
         {
           classNames: 'label',
-          content: 'Configure CCPU version'
+          content: 'Configure CCPU and hardware versions'
         }
       ),
       backButton: SDL.Button.extend(
@@ -70,12 +72,26 @@ SDL.CcpuEditorView = Em.ContainerView.create(
           valueBinding: 'SDL.SettingsController.editedCcpuVersionValue'
         }
       ),
+      hardwareVersionLabel: SDL.Label.extend(
+        {
+          classNames: 'hardwareVersionLabel',
+          content: 'Hardware version: '
+        }
+      ),
+      hardwareVersionInput: Ember.TextField.extend(
+        {
+          elementId: 'hardwareVersionInput',
+          classNames: 'hardwareVersionInput dataInput',
+          placeholder: '<Type hardware version here>',
+          valueBinding: 'SDL.SettingsController.editedHardwareVersionValue'
+        }
+      ),
       applyButton: SDL.Button.extend(
         {
           elementId: 'applyButton',
           classNames: 'applyButton button',
           text: 'Apply',
-          action: 'applyNewCcpuVersionValue',
+          action: 'applyNewVersionValues',
           target: 'SDL.SettingsController',
           onDown: false
         }

--- a/app/view/settings/policies/systemVersionsEditorView.js
+++ b/app/view/settings/policies/systemVersionsEditorView.js
@@ -36,6 +36,7 @@ SDL.SystemVersionsEditorView = Em.ContainerView.create(
         'backButton',
         'ccpuVersionLabel',
         'ccpuVersionInput',
+        'hardwareVersionCheckBox',
         'hardwareVersionLabel',
         'hardwareVersionInput',
         'applyButton'
@@ -72,6 +73,13 @@ SDL.SystemVersionsEditorView = Em.ContainerView.create(
           valueBinding: 'SDL.SettingsController.editedCcpuVersionValue'
         }
       ),
+      hardwareVersionCheckBox: Em.Checkbox.extend(
+        {
+          elementId: 'hardwareVersionCheckBox',
+          classNames: 'hardwareVersionCheckBox item',
+          checkedBinding: 'SDL.SettingsController.hardwareVersionEditingEnabled'
+        }
+      ),
       hardwareVersionLabel: SDL.Label.extend(
         {
           classNames: 'hardwareVersionLabel',
@@ -83,7 +91,11 @@ SDL.SystemVersionsEditorView = Em.ContainerView.create(
           elementId: 'hardwareVersionInput',
           classNames: 'hardwareVersionInput dataInput',
           placeholder: '<Type hardware version here>',
-          valueBinding: 'SDL.SettingsController.editedHardwareVersionValue'
+          valueBinding: 'SDL.SettingsController.editedHardwareVersionValue',
+          disabledBinding: 'isEditingEnabled',
+          isEditingEnabled: function() {
+            return !SDL.SettingsController.hardwareVersionEditingEnabled;
+          }.property('SDL.SettingsController.hardwareVersionEditingEnabled')
         }
       ),
       applyButton: SDL.Button.extend(

--- a/app/view/settings/policies/systemVersionsEditorView.js
+++ b/app/view/settings/policies/systemVersionsEditorView.js
@@ -100,8 +100,8 @@ SDL.SystemVersionsEditorView = Em.ContainerView.create(
       ),
       applyButton: SDL.Button.extend(
         {
-          elementId: 'applyButton',
-          classNames: 'applyButton button',
+          elementId: 'systemVersionsApplyButton',
+          classNames: 'systemVersionsApplyButton button',
           text: 'Apply',
           action: 'applyNewVersionValues',
           target: 'SDL.SettingsController',

--- a/app/view/settings/policies/vehicleTypeEditorView.js
+++ b/app/view/settings/policies/vehicleTypeEditorView.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met: ·
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. · Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution. · Neither the name of the Ford Motor Company nor the
+ * names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+SDL.VehicleTypeEditorView = Em.ContainerView.create(
+    {
+      elementId: 'policies_settings_vehicle_type_editor_view',
+      classNames: 'in_settings_separate_view',
+      classNameBindings: [
+        'SDL.States.settings.policies.vehicleTypeEditor.active:active_state:inactive_state'
+      ],
+      childViews: [
+        'versionsTitle',
+        'backButton',
+        'vehicleMakeLabel',
+        'vehicleMakeCheckBox',
+        'vehicleMakeInput',
+
+        'vehicleModelLabel',
+        'vehicleModelCheckBox',
+        'vehicleModelInput',
+
+        'vehicleYearLabel',
+        'vehicleYearCheckBox',
+        'vehicleYearInput',
+
+        'vehicleTrimLabel',
+        'vehicleTrimCheckBox',
+        'vehicleTrimInput',
+
+        'applyButton'
+      ],
+      versionsTitle: SDL.Label.extend(
+        {
+          classNames: 'label',
+          content: 'Configure vehicle type parameters'
+        }
+      ),
+      backButton: SDL.Button.extend(
+        {
+          classNames: [
+            'backButton'
+          ],
+          action: 'onState',
+          target: 'SDL.SettingsController',
+          goToState: 'policies',
+          icon: 'images/media/ico_back.png',
+          onDown: false
+        }
+      ),
+      vehicleMakeLabel: SDL.Label.extend(
+        {
+          classNames: 'vehicleMakeLabel vehicleBaseLabel',
+          content: 'Make: '
+        }
+      ),
+      vehicleMakeCheckBox: Em.Checkbox.extend(
+        {
+          elementId: 'vehicleMakeCheckBox',
+          classNames: 'vehicleMakeCheckBox vehicleBaseCheckBox item',
+
+          click: function(event) {
+            SDL.VehicleTypeEditorView.vehicleMakeInput.set('disabled', !event.currentTarget.checked)
+          }
+        }
+      ),
+      vehicleMakeInput: Ember.TextField.extend(
+        {
+          elementId: 'vehicleMakeInput',
+          classNames: 'vehicleMakeInput vehicleBaseInput dataInput',
+          placeholder: '<Type vehicle make here>',
+          valueBinding: 'SDL.SettingsController.editedVehicleType.make'
+        }
+      ),
+
+      vehicleModelLabel: SDL.Label.extend(
+        {
+          classNames: 'vehicleModelLabel vehicleBaseLabel',
+          content: 'Model: '
+        }
+      ),
+      vehicleModelCheckBox: Em.Checkbox.extend(
+        {
+          elementId: 'vehicleModelCheckBox',
+          classNames: 'vehicleModelCheckBox vehicleBaseCheckBox item',
+
+          click: function(event) {
+            SDL.VehicleTypeEditorView.vehicleModelInput.set('disabled', !event.currentTarget.checked)
+          }
+        }
+      ),
+      vehicleModelInput: Ember.TextField.extend(
+        {
+          elementId: 'vehicleModelInput',
+          classNames: 'vehicleModelInput vehicleBaseInput dataInput',
+          placeholder: '<Type vehicle model here>',
+          valueBinding: 'SDL.SettingsController.editedVehicleType.model'
+        }
+      ),
+
+      vehicleYearLabel: SDL.Label.extend(
+        {
+          classNames: 'vehicleYearLabel vehicleBaseLabel',
+          content: 'Year: '
+        }
+      ),
+      vehicleYearCheckBox: Em.Checkbox.extend(
+        {
+          elementId: 'vehicleYearCheckBox',
+          classNames: 'vehicleYearCheckBox vehicleBaseCheckBox item',
+
+          click: function(event) {
+            SDL.VehicleTypeEditorView.vehicleYearInput.set('disabled', !event.currentTarget.checked)
+          }
+        }
+      ),
+      vehicleYearInput: Ember.TextField.extend(
+        {
+          elementId: 'vehicleYearInput',
+          classNames: 'vehicleYearInput vehicleBaseInput dataInput',
+          placeholder: '<Type vehicle year here>',
+          valueBinding: 'SDL.SettingsController.editedVehicleType.modelYear'
+        }
+      ),
+
+      vehicleTrimLabel: SDL.Label.extend(
+        {
+          classNames: 'vehicleTrimLabel vehicleBaseLabel',
+          content: 'Trim: '
+        }
+      ),
+      vehicleTrimCheckBox: Em.Checkbox.extend(
+        {
+          elementId: 'vehicleTrimCheckBox',
+          classNames: 'vehicleTrimCheckBox vehicleBaseCheckBox item',
+
+          click: function(event) {
+            SDL.VehicleTypeEditorView.vehicleTrimInput.set('disabled', !event.currentTarget.checked)
+          }
+        }
+      ),
+      vehicleTrimInput: Ember.TextField.extend(
+        {
+          elementId: 'vehicleTrimInput',
+          classNames: 'vehicleTrimInput vehicleBaseInput dataInput',
+          placeholder: '<Type vehicle trim here>',
+          valueBinding: 'SDL.SettingsController.editedVehicleType.trim'
+        }
+      ),
+
+
+      applyButton: SDL.Button.extend(
+        {
+          elementId: 'vehicleTypeApplyButton',
+          classNames: 'vehicleTypeApplyButton button',
+          text: 'Apply',
+          action: 'applyNewVehicleTypeValues',
+          target: 'SDL.SettingsController',
+          onDown: false
+        }
+      )
+    }
+  );

--- a/app/view/settings/policiesView.js
+++ b/app/view/settings/policiesView.js
@@ -97,6 +97,17 @@ SDL.PoliciesView = Em.ContainerView.create(
           {
             type: SDL.Button,
             params: {
+              action: 'onState',
+              goToState: 'policies.vehicleTypeEditor',
+              text: 'Configure vehicle type parameters',
+              target: 'SDL.SettingsController',
+              templateName: 'arrow',
+              onDown: false,
+            }
+          },
+          {
+            type: SDL.Button,
+            params: {
               goToState: 'policies.deviceConfig',
               text: 'Allow SDL Functionality',
               action: 'onState',

--- a/app/view/settings/policiesView.js
+++ b/app/view/settings/policiesView.js
@@ -87,8 +87,8 @@ SDL.PoliciesView = Em.ContainerView.create(
             type: SDL.Button,
             params: {
               action: 'onState',
-              goToState: 'policies.ccpuEditor',
-              text: 'Configure CCPU version',
+              goToState: 'policies.versionsEditor',
+              text: 'Configure CCPU and hardware versions',
               target: 'SDL.SettingsController',
               templateName: 'arrow',
               onDown: false,

--- a/app/view/settingsView.js
+++ b/app/view/settingsView.js
@@ -63,7 +63,7 @@ SDL.SettingsView = Em.ContainerView.create(
       SDL.ExteriorLightView,
       SDL.SeatView,
       SDL.PolicyConfigListView,
-      SDL.CcpuEditorView
+      SDL.SystemVersionsEditorView
     ],
     /** Left menu */
     leftMenu: Em.ContainerView.extend(

--- a/app/view/settingsView.js
+++ b/app/view/settingsView.js
@@ -63,7 +63,8 @@ SDL.SettingsView = Em.ContainerView.create(
       SDL.ExteriorLightView,
       SDL.SeatView,
       SDL.PolicyConfigListView,
-      SDL.SystemVersionsEditorView
+      SDL.SystemVersionsEditorView,
+      SDL.VehicleTypeEditorView
     ],
     /** Left menu */
     leftMenu: Em.ContainerView.extend(

--- a/css/settings.css
+++ b/css/settings.css
@@ -347,6 +347,80 @@
     width: 450px;
 }
 
+#settingsView .in_settings_separate_view .label.vehicleBaseLabel {
+    position: absolute;
+    left: 35px;
+    background: black;
+    width: 120px;
+}
+
+#settingsView .in_settings_separate_view .vehicleBaseInput {
+    position: absolute;
+    left: 120px;
+    width: 609px;
+}
+
+#settingsView .in_settings_separate_view .vehicleBaseInput:disabled {
+    color: gray;
+}
+
+#settingsView .in_settings_separate_view .vehicleBaseCheckBox {
+    position: absolute;
+    left: 25px;
+    z-index: 2;
+}
+
+#settingsView .in_settings_separate_view .label.vehicleMakeLabel {
+    top: 110px;
+}
+
+#settingsView .in_settings_separate_view .vehicleMakeInput {
+    top: 115px;
+}
+
+#settingsView .in_settings_separate_view .vehicleMakeCheckBox {
+    top: 127px;
+}
+
+
+#settingsView .in_settings_separate_view .label.vehicleModelLabel {
+    top: 170px;
+}
+
+#settingsView .in_settings_separate_view .vehicleModelInput {
+    top: 175px;
+}
+
+#settingsView .in_settings_separate_view .vehicleModelCheckBox {
+    top: 187px;
+}
+
+
+#settingsView .in_settings_separate_view .label.vehicleYearLabel {
+    top: 230px;
+}
+
+#settingsView .in_settings_separate_view .vehicleYearInput {
+    top: 235px;
+}
+
+#settingsView .in_settings_separate_view .vehicleYearCheckBox {
+    top: 247px;
+}
+
+
+#settingsView .in_settings_separate_view .label.vehicleTrimLabel {
+    top: 290px;
+}
+
+#settingsView .in_settings_separate_view .vehicleTrimInput {
+    top: 295px;
+}
+
+#settingsView .in_settings_separate_view .vehicleTrimCheckBox {
+    top: 307px;
+}
+
 #settingsView .in_settings_separate_view .hardwareVersionInput {
     position: absolute;
     left: 190px;
@@ -365,12 +439,20 @@
     z-index: 2;
 }
 
-#settingsView .in_settings_separate_view .applyButton {
+#settingsView .in_settings_separate_view .systemVersionsApplyButton {
     position: absolute;
-    left: 190px;
     top: 250px;
+    left: 190px;
     width: 125px;
     text-align: center;
+}
+
+#settingsView .in_settings_separate_view .vehicleTypeApplyButton {
+    position: absolute;
+    top: 338px;
+    width: 125px;
+    text-align: center;
+    right: 6px;
 }
 
 #settingsView .in_settings_separate_view .label.ccpuVersionLabel {

--- a/css/settings.css
+++ b/css/settings.css
@@ -342,16 +342,34 @@
 
 #settingsView .in_settings_separate_view .ccpuVersionInput {
     position: absolute;
-    left: 145px;
+    left: 190px;
     top: 115px;
-    width: 400px;
+    width: 450px;
+}
+
+#settingsView .in_settings_separate_view .hardwareVersionInput {
+    position: absolute;
+    left: 190px;
+    top: 190px;
+    width: 450px;
+}
+
+#settingsView .in_settings_separate_view .hardwareVersionInput:disabled {
+    color: gray;
+}
+
+#settingsView .in_settings_separate_view .hardwareVersionCheckBox {
+    position: absolute;
+    left: 25px;
+    top: 203px;
+    z-index: 2;
 }
 
 #settingsView .in_settings_separate_view .applyButton {
     position: absolute;
-    left: 585px;
-    top: 115px;
-    width: 75px;
+    left: 190px;
+    top: 250px;
+    width: 125px;
     text-align: center;
 }
 
@@ -361,6 +379,14 @@
     left: 10px;
     background: black;
     width: 120px;
+}
+
+#settingsView .in_settings_separate_view .label.hardwareVersionLabel {
+    position: absolute;
+    top: 185px;
+    left: 30px;
+    background: black;
+    width: 150px;
 }
 
 #settingsView .in_settings_separate_view .sendRequestButton {

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -704,6 +704,9 @@ FFW.BasicCommunication = FFW.RPCObserver
                 'wersCountryCode': 'wersCountryCode'
               }
             };
+            if (SDL.SDLModel.data.hardwareVersion != null) {
+              JSONMessage.result.systemHardwareVersion = SDL.SDLModel.data.hardwareVersion;
+            }
             this.sendMessage(JSONMessage);
           }
           if (request.method == 'BasicCommunication.PolicyUpdate') {

--- a/index.html
+++ b/index.html
@@ -241,6 +241,7 @@
 <script type="text/javascript" src="app/view/settings/HMISettingsView.js"></script>
 <script type="text/javascript" src="app/view/settings/policies/policyConfigDataList.js"></script>
 <script type="text/javascript" src="app/view/settings/policies/systemVersionsEditorView.js"></script>
+<script type="text/javascript" src="app/view/settings/policies/vehicleTypeEditorView.js"></script>
 
 <!-- RPCControls view-->
 <script type="text/javascript"

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
 <script type="text/javascript" src="app/view/settings/policiesView.js"></script>
 <script type="text/javascript" src="app/view/settings/HMISettingsView.js"></script>
 <script type="text/javascript" src="app/view/settings/policies/policyConfigDataList.js"></script>
-<script type="text/javascript" src="app/view/settings/policies/ccpuEditorView.js"></script>
+<script type="text/javascript" src="app/view/settings/policies/systemVersionsEditorView.js"></script>
 
 <!-- RPCControls view-->
 <script type="text/javascript"


### PR DESCRIPTION
Implements 0293 proposal

**This PR will be redirected to smartDeviceLink organization after the revision will be accepted**

This PR is **ready** for review.

### Testing Plan
Tested manually

**Note:**  [Manual instruction for Enable OEM exclusive apps support v1.0.zip](https://github.com/LuxoftSDL/sdl_hmi/files/5820588/Manual.instruction.for.Enable.OEM.exclusive.apps.support.v1.0.zip)


### Summary
- Renamed CCPU editor to versions editor
- Added hardware version parameter support and updated styles for affected controls
- Added possibility to edit vehicle type structure and optional fields sending

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
