### PR TITLE
Fix AlertManeuver pop-up shown contains only appID

### DIFF
--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -263,7 +263,7 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       this.set('alertManeuerRequestId', message.id);
       this.addSoftButtons(message.params);
 
-      if(this.softbuttons.buttons.lengthAfterRender > 0){
+      if (this.softbuttons.buttons.lengthAfterRender > 0) {
         this.set('activate', true );
         clearTimeout( this.timer );
         this.timer = setTimeout( () => {

--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -263,12 +263,13 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       this.set('alertManeuerRequestId', message.id);
       this.addSoftButtons(message.params);
 
-      this.set('activate', true );
-
-      clearTimeout( this.timer );
-      this.timer = setTimeout( () => {
-        this.deactivate(message);
-      }, this.timeout);
+      if(this.softbuttons.buttons.lengthAfterRender > 0){
+        this.set('activate', true );
+        clearTimeout( this.timer );
+        this.timer = setTimeout( () => {
+          this.deactivate(message);
+        }, this.timeout);
+      }      
     }
   }
 );


### PR DESCRIPTION
Fixes (https://adc.luxoft.com/jira/browse/FORDTCN-7780)

This PR is **not ready** for review.

### Testing Plan
Covered by manual test plan

### Summary
There was noticed HMI shows the empty AlertManeuver pop-up in case Navi.AlertManeuveruver request contains only appID. 
Has been added a check for the presence of softbuttons in the AlertManeuver request. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
