### PR TITLE
Fix HMI sends deprecated on find applications notification

### DIFF
--- a/app/StateManager.js
+++ b/app/StateManager.js
@@ -108,7 +108,6 @@ var StateManager = Em.StateManager.extend(
              */
             enter: function() {
               this._super();
-              FFW.BasicCommunication.OnFindApplications();
             }
           }
         ),

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -1282,13 +1282,7 @@ SDL.SDLController = Em.Object.extend(
         element.id
       );
       this.turnChangeDeviceViewBack();
-    },
-    /**
-     * Method call's request to get list of applications
-     */
-    findNewApps: function() {
-      FFW.BasicCommunication.OnFindApplications();
-    },
+    },    
     /**
      * Method activates selected registered application
      *

--- a/app/view/info/appsView.js
+++ b/app/view/info/appsView.js
@@ -42,7 +42,6 @@ SDL.InfoAppsView = Em.ContainerView.create({
   childViews: [
     'vehicleHealthReport',
     'Asist911',
-    'findNewApps',
     'getDeviceList',
     'applicationsStore',
     'listOfApplications'
@@ -126,19 +125,6 @@ SDL.InfoAppsView = Em.ContainerView.create({
       }
     ),
 
-  findNewApps: SDL.Button.extend({
-        goToState: 'settings.system.installApplications',
-        icon: 'images/sdl/new_apps.png',
-        textBinding: 'SDL.locale.label.view_info_apps_vehicle_FindNewApplications',
-        elementId: 'infoAppsFindNewApps',
-        classNames: 'button findNewApps leftButtons',
-        arrow: true,
-        action: 'findNewApps',
-        target: 'SDL.SDLController',
-        onDown: false
-      }
-    ),
-
   getDeviceList: SDL.Button.extend({
         icon: 'images/sdl/devices.png',
         textBinding: 'SDL.locale.label.view_info_apps_vehicle_GetDeviceList',
@@ -177,8 +163,7 @@ SDL.InfoAppsView = Em.ContainerView.create({
   /**
    * @description Callback for display image mode change.
    */
-  imageModeChanged: function() { 
-    SDL.InfoAppsView.findNewApps.setMode(SDL.SDLModel.data.imageMode);
+  imageModeChanged: function() {
     SDL.InfoAppsView.Asist911.setMode(SDL.SDLModel.data.imageMode);
     SDL.InfoAppsView.vehicleHealthReport.setMode(SDL.SDLModel.data.imageMode);
     SDL.InfoAppsView.getDeviceList.setMode(SDL.SDLModel.data.imageMode);

--- a/css/info.css
+++ b/css/info.css
@@ -617,17 +617,8 @@
 	top: 122px;
 }
 
-#info_apps .findNewApps {
-	top: 174px;
-}
-
-#info_apps .findNewApps img {
-	margin: 9px;
-	width: 32px;
-}
-
 #info_apps .getDeviceList {
-	top: 226px;
+	top: 174px;
 }
 
 #info_apps .getDeviceList img {
@@ -636,7 +627,7 @@
 }
 
 #info_apps .appsStore {
-	top: 278px;
+	top: 226px;
 }
 
 #info_apps .appsStore img {

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -531,7 +531,6 @@ FFW.BasicCommunication = FFW.RPCObserver
             appModel, notification.params.vrSynonyms
           );
           FFW.RPCHelper.addApplication(notification.params.application.appID);
-          this.OnFindApplications();
           const mainWindowID = 0;
           let capability = SDL.SDLController.getDefaultCapabilities(mainWindowID, notification.params.application.appID);
           FFW.BasicCommunication.OnSystemCapabilityUpdated(capability);
@@ -1317,23 +1316,6 @@ FFW.BasicCommunication = FFW.RPCObserver
             }
           }
         };
-        this.sendMessage(JSONMessage);
-      },
-      /**
-       * This methos is request to get list of registered apps.
-       */
-      OnFindApplications: function() {
-        Em.Logger.log('FFW.BasicCommunication.OnFindApplications');
-        var JSONMessage = {
-          'jsonrpc': '2.0',
-          'method': 'BasicCommunication.OnFindApplications'
-        };
-        if (SDL.SDLModel.data.CurrDeviceInfo.name ||
-          SDL.SDLModel.data.CurrDeviceInfo.id) {
-          JSONMessage.params = {
-            'deviceInfo': SDL.SDLModel.data.CurrDeviceInfo
-          };
-        }
         this.sendMessage(JSONMessage);
       },
       /**

--- a/locale/eng.js
+++ b/locale/eng.js
@@ -15,7 +15,6 @@ SDL.eng = {
   view_info_apps_vehicle_VehicleHealthReport: 'Vehicle Health Report',
   view_info_apps_vehicle_InstallApplicationsUp: 'Install Applications/Up',
   view_info_apps_vehicle_DeviceLocation: 'Device Location',
-  view_info_apps_vehicle_FindNewApplications: 'Find New Apps',
   view_info_apps_vehicle_GetDeviceList: 'Change Devices',
   view_info_apps_vehicle_ApplicationsStore: 'App Store',
   view_info_calendar_date: 'Jul, 2012',


### PR DESCRIPTION
Fixes (https://adc.luxoft.com/jira/browse/FORDTCN-10666)

This PR is **not ready** for review.

### Testing Plan
Covered by manual test plan

### Summary
Was fixed sending deprecated notification OnFindApplications to SDL. Also was removed button "Find New Apps" as it also sent deprecated notification OnFindApplications.

## CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
