### PR TITLE
Fix HMI shows the empty last selection in the drop-down resolution list

### DIFF
--- a/app/view/navigationApp/baseNavigationView.js
+++ b/app/view/navigationApp/baseNavigationView.js
@@ -184,7 +184,7 @@ SDL.BaseNavigationView = Em.ContainerView.create(
       ),
 
       getResolutionValue: function() {
-        if (SDL.NavigationModel.resolutionIndex < SDL.NavigationModel.resolutionsList.length - 1) {
+        if (SDL.NavigationModel.resolutionIndex < SDL.NavigationModel.resolutionsList.length) {
           return SDL.NavigationController.stringifyCapabilityItem(
             SDL.NavigationModel.resolutionsList[SDL.NavigationModel.resolutionIndex]
           );


### PR DESCRIPTION
Fixes (https://adc.luxoft.com/jira/browse/FORDTCN-11031)

This PR is **ready** for review.

### Testing Plan
Covered by manual test plan

### Summary
Was fixed HMI shows the empty last selection in the drop-down list with the resolutions.



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
