### PR TITLE
Fix HMI does not send AddSubMenu and SetGlobalProperties response with settable resultCode

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -777,11 +777,15 @@ SDL.ABSAppModel = Em.Object.extend(
             var callback = function(failed, info) {
               var WARNINGS = SDL.SDLModel.data.resultCode.WARNINGS;
               var SUCCESS = SDL.SDLModel.data.resultCode.SUCCESS;
+              var finalCode = failed ? WARNINGS : SUCCESS;
+              if (result != SUCCESS){
+                finalCode = result;
+              }
 
               FFW.UI.sendUIResult(
-                failed ? WARNINGS : SUCCESS, 
-                request.id, 
-                request.method, 
+                finalCode,
+                request.id,
+                request.method,
                 info);
             }
             var imageList = [];

--- a/ffw/TTSRPC.js
+++ b/ffw/TTSRPC.js
@@ -172,7 +172,10 @@ FFW.TTS = FFW.RPCObserver.create(
           let info = null;
 
           if(FFW.RPCHelper.isSuccessResultCode(resultCode)){
-            resultCode = SDL.SDLModel.setProperties(request.params);
+            const setResultCode = SDL.SDLModel.setProperties(request.params);
+            if (resultCode == SDL.SDLModel.data.resultCode.SUCCESS){
+              resultCode = setResultCode;
+            }
           } else {
             info = 'Erroneous response is assigned by settings';
           }

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -273,7 +273,7 @@ FFW.UI = FFW.RPCObserver.create(
           let info = null;
           
           if(FFW.RPCHelper.isSuccessResultCode(resultCode)){
-            resultCode = SDL.SDLModel.setProperties(request.params);
+            const setResultCode = SDL.SDLModel.setProperties(request.params);
 
             var imageList = [];
             if(request.params.menuIcon) {
@@ -288,17 +288,24 @@ FFW.UI = FFW.RPCObserver.create(
               }
             }
 
-            var that = this;
             var callback = function(failed, info) {
               var WARNINGS = SDL.SDLModel.data.resultCode.WARNINGS;
-              var SUCCESS = resultCode;
+              var SUCCESS = SDL.SDLModel.data.resultCode.SUCCESS;
+              var finalCode = failed ? WARNINGS : SUCCESS;
+              if (finalCode != SUCCESS){
+                finalCode = setResultCode;
+              }
+              if (resultCode != SUCCESS){
+                finalCode = resultCode;
+              }
 
-              that.sendUIResult(
-                failed ? WARNINGS : SUCCESS,
+              FFW.UI.sendUIResult(
+                finalCode,
                 request.id,
                 request.method,
                 info);
             }
+            
             SDL.SDLModel.validateImages(request.id, callback, imageList);
             break;
           } else {


### PR DESCRIPTION
Fixes (https://adc.luxoft.com/jira/browse/FORDTCN-11549)

This PR is **ready** for review.

### Testing Plan
Mobile application is registered and activated, on HMI go to Setting -> RPC Control -> App name ->  AddSubMenu or SetGlobalProperties set resultCode "WARNINGS"(WRONG_LANGUAGE, RETRY,SAVED)
  from the drop-down list and click "SAVE" button, send AddSubMenu (params) or SetGlobalProperties (params);  observe HMI responds with correspond resultCode.

### Summary
Fixed HMI does not send AddSubMenu and SetGlobalProperties response with settable resultCode.
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
