### PR TITLE
HMI does not send Speak response by softButton press within Alert and SubtitleAlert RPCs

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1875,6 +1875,10 @@ FFW.UI = FFW.RPCObserver.create(
       };
 
       Em.Logger.log('FFW.UI.' + method + 'Response');
+      if (SDL.ResetTimeoutPopUp.resetTimeoutRPCs.includes('TTS.Speak')) {
+        SDL.SDLController.TTSResponseHandler();
+        SDL.ResetTimeoutPopUp.resetTimeoutRPCs.removeObject('TTS.Speak');
+      }
       if (is_successful_response_format(is_successful_code)) {
         // send response
         var JSONMessage = {


### PR DESCRIPTION
… SubtitleAlert RPCs


This PR is **[ready]** for review.

### Testing Plan
1.Mobile app requests `Alert` or `SubtitleAlert` RPC with ttsChunks and with softButtons
2.Press `Close` button when timer for speak is not expired

