### PR TITLE
Fixed HMI shows identical navigation buttons for all registered apps

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -63,7 +63,7 @@ SDL.ABSAppModel = Em.Object.extend(
      * navigation subscription buttons.
      * Depends on BC.SubscribeButton request.
      */    
-    NAV_BUTTONS: {
+    NAV_BUTTONS_INITIAL: {
         NAV_CENTER_LOCATION: {
           subscribed: false,
           text: "Center"

--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -42,6 +42,7 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
     for (var key in SDL.SDLVehicleInfoModel.vehicleData) {
       subscribeVIData[key] = false;
     }
+    this.NAV_BUTTONS = SDL.deepCopy(this.NAV_BUTTONS_INITIAL);
 
     this.set('subscribedData', subscribeVIData);
 

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -43,6 +43,8 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
       subscribeVIData[key] = false;
     }
 
+    this.NAV_BUTTONS = SDL.deepCopy(this.NAV_BUTTONS_INITIAL);
+
     this.set('subscribedData', subscribeVIData);
 
     // init properties here


### PR DESCRIPTION
Fixes (https://adc.luxoft.com/jira/browse/FORDTCN-12379)

This PR is **ready** for review.

### Testing Plan
SDL and HMI are started, mobile device connected;
Navigation app1 and navigation app2;
Mobile navigation app1 is activated;
Mobile app requests ButtonSubscriptions for of navigation buttons (e.g. NAV_ZOOM_IN, NAV_ZOOM_OUT);
Go to Nav Buttons on app1 HMI screen;
Go to Nav Buttons on app2 HMI screen;
Observe HMI shows buttons with an active subscription for app1 in Nav Buttons menu and does not show these buttons for app2 that has no active subscription for these buttons.

### Summary
Fixed HMI shows identical navigation buttons for all registered apps

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
