### PR TITLE
Fix of reset timeout counter out of window

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -377,7 +377,7 @@ button.next-home {
 }
 
 #ResetTimeoutPopUp {
-    left: 1500px;
+    left: 1450px;
     width: 302px;
     height: 147px;
     top: 10px;
@@ -444,7 +444,6 @@ button.next-home {
     height: 31px;
     top: 257px;
     white-space: pre;
-    left: 118px;
     text-align: center;
     line-height: 30px;
 }


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Reset Timeout popup counter moved to the left side of the view

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
