### PR TITLE
Fixed issue: HMI Uncaught ReferenceError during processing SetDisplayLayout(displayLayout = DEFAULT) for navigation app

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -517,7 +517,7 @@ FFW.UI = FFW.RPCObserver.create(
             if (displayLayout === "DEFAULT") {
               for (var i=0; i<model.appType.length; i++) {
                 if (model.appType[i] === "NAVIGATION") {
-                  displayLayout = NAV_FULLSCREEN_MAP;
+                  displayLayout = "NAV_FULLSCREEN_MAP";
                   break;
                 }
               }


### PR DESCRIPTION
Fixes [#12544](https://adc.luxoft.com/jira/browse/FORDTCN-12544)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
The PR contain fix for the issue with Uncaught ref error for SetDisplayLayout request.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
