### PR TITLE
Fix Get IVD consent doesnt close reset timeout popup

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -546,6 +546,7 @@ SDL.RController = SDL.SDLController.extend(
           function(result) {
             allowed.push(result);
             if(allowed.length == moduleIds.length) {
+              SDL.ResetTimeoutPopUp.stopRpcProcessing(request.method);
               FFW.RC.GetInteriorVehicleDataConsentResponse(request, allowed);
             }
           }


### PR DESCRIPTION
Fixes [#AAW-12548](https://adc.luxoft.com/jira/browse/FORDTCN-12548)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added method call `stopRpcProcessing` of ResetTimeoutPopUp before sending Get IVD Consent response

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
