### PR TITLE
Fixed issue: Cannot read property 'removeClass' of undefined by switching  of Display mode and during active PerformInteraction

### DIFF
--- a/app/view/sdl/shared/interactionChoicesView.js
+++ b/app/view/sdl/shared/interactionChoicesView.js
@@ -310,8 +310,9 @@ SDL.InteractionChoicesView = SDL.SDLAbstractView.create(
       this.listOfChoices.list.refresh();
       var length = this.get('listWrapper.naviChoises.childViews').length;
       for (var i = 0; i < length; i++) {
-        SDL.InteractionChoicesView.get('listWrapper.naviChoises.childViews')
+        const obj = SDL.InteractionChoicesView.get('listWrapper.naviChoises.childViews')
           .shiftObject();
+        obj.destroy();
       }
     },
     /**


### PR DESCRIPTION
Fixes [#FORDTCN-12545](https://adc.luxoft.com/jira/browse/FORDTCN-12545)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
The childviews of `naviChoices` container were shifted but not destroyed. It kept triggering events like display mode change for the shifted but not destroyed elements. Added `destroy` method call for those elements after shifting them from container.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
