### PR TITLE
Fixed regression issue: HMI does not wait timeout on button Reset timeout pressed during SubtleAlert processing

### DIFF
--- a/app/view/sdl/SubtleAlertPopUp.js
+++ b/app/view/sdl/SubtleAlertPopUp.js
@@ -59,6 +59,14 @@ SDL.SubtleAlertPopUp = Em.ContainerView.create(
         reason: '',
         message: undefined,
         click(event) {
+            const path = event.path;
+            for(const pathElement of path) {
+                if ('className' in pathElement
+                    && typeof pathElement.className === 'string'
+                    && pathElement.className.match(/resetTimeoutButton|ResetTimeoutPopUp/)) {
+                        return;
+                    }
+            }
             if (document.getElementById('SubtleAlertPopUp').contains(event.target)){
                 var buttonsDiv = document.getElementById('subtleAlertSoftButtons');
                 for (var button of buttonsDiv.childNodes) {


### PR DESCRIPTION
Fixes [#FORDTCN-12731](https://adc.luxoft.com/jira/browse/FORDTCN-12731)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added check that the resetTimeoutButton was pressed

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
