### PR TITLE
Fixed issue: HMI sends RETRY result code in error structure

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -917,7 +917,8 @@ SDL.SDLController = Em.Object.extend(
      */
     performAudioPassThruResponse: function(result) {
       SDL.SDLModel.data.set('AudioPassThruState', false);
-      if (result === SDL.SDLModel.data.resultCode.SUCCESS) {
+      if (result === SDL.SDLModel.data.resultCode.SUCCESS
+         || result === SDL.SDLModel.data.resultCode.RETRY) {
         FFW.UI.sendUIResult(
           result,
           FFW.UI.performAudioPassThruRequestID,

--- a/app/view/sdl/AudioPassThruPopUp.js
+++ b/app/view/sdl/AudioPassThruPopUp.js
@@ -97,7 +97,7 @@ SDL.AudioPassThruPopUp = Em.ContainerView.create(
         text: 'Retry',
         responseResult: SDL.SDLModel.data.resultCode['RETRY'],
         actionUp: function() {
-          SDL.SDLController.callPerformAudioPassThruPopUpErrorResponse(this);
+          SDL.SDLController.callPerformAudioPassThruPopUpResponse(this);
         }
       }
     ),


### PR DESCRIPTION
Implements/Fixes [#AAW-1294](https://luxproject.luxoft.com/jira/browse/AAW-1294)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Changed response structure of `PerformAudioPassThru` response

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
