### PR TITLE
Fixed issue: HMI does not stop play audio whtn PHONE_CALL event happend

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -116,6 +116,7 @@ SDL.SettingsController = Em.Object.create(
       FFW.BasicCommunication.GetStatusUpdate();
     },
     phoneCall: function() {
+      SDL.StreamAudio.toggleMute();
       SDL.SDLController.onEventChanged('phoneCall', true);
       SDL.SDLModel.data.phoneCallActive = true;
       var appID = null;
@@ -130,6 +131,7 @@ SDL.SettingsController = Em.Object.create(
             SDL.SDLController.onEventChanged('phoneCall', false);
             SDL.SDLController.getApplicationModel(appID).turnOnSDL(appID);
             SDL.SDLModel.data.phoneCallActive = false;
+            SDL.StreamAudio.toggleMute();
           }, 20000
         ); //Magic number - 5 seconds timeout for emulating conversation call
       } else {
@@ -137,6 +139,7 @@ SDL.SettingsController = Em.Object.create(
           function() {
             SDL.SDLController.onEventChanged('phoneCall', false);
             SDL.SDLModel.data.phoneCallActive = false;
+            SDL.StreamAudio.toggleMute();
           }, 20000
         ); //Magic number - 5 seconds timeout for emulating conversation call
       }

--- a/app/util/StreamAudio.js
+++ b/app/util/StreamAudio.js
@@ -57,5 +57,9 @@ SDL.StreamAudio = {
       this.audio.src = '';
       this.audio.pause();
     }
+  },
+
+  toggleMute: function() {
+    this.audio.muted = !this.audio.muted;
   }
 };


### PR DESCRIPTION
Fixes 
Task: [HMI] HMI doesn't stop play audio when PHONE_CALL event happend

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added stopStreams function to phone call action

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
